### PR TITLE
chore: avoid implicit lib function addressing

### DIFF
--- a/modules/boot.nix
+++ b/modules/boot.nix
@@ -4,24 +4,22 @@ let
   cfg = config.settings.boot;
 in
 
-with lib;
-
 {
   options = {
     settings.boot = {
-      mode = mkOption {
-        type = types.enum (attrValues cfg.modes);
+      mode = lib.mkOption {
+        type = lib.types.enum (lib.attrValues cfg.modes);
         description = "Boot in either legacy or UEFI mode.";
       };
 
-      separate_partition = mkOption {
-        type = types.bool;
+      separate_partition = lib.mkOption {
+        type = lib.types.bool;
         default = true;
         description = "Whether /boot is a separate partition.";
       };
 
-      modes = mkOption {
-        type = with types; attrsOf str;
+      modes = lib.mkOption {
+        type = with lib.types; attrsOf str;
         default = { legacy = "legacy"; uefi = "uefi"; none = "none"; };
         readOnly = true;
       };
@@ -41,14 +39,14 @@ with lib;
         let
           inherit (cfg) mode;
         in
-        mkIf (mode != cfg.modes.none) (mkMerge [
-          (mkIf (mode == cfg.modes.legacy) {
+        lib.mkIf (mode != cfg.modes.none) (lib.mkMerge [
+          (lib.mkIf (mode == cfg.modes.legacy) {
             grub = {
               enable = true;
               configurationLimit = 15;
             };
           })
-          (mkIf (mode == cfg.modes.uefi) {
+          (lib.mkIf (mode == cfg.modes.uefi) {
             systemd-boot = {
               enable = true;
               editor = false;
@@ -80,7 +78,7 @@ with lib;
         "kernel.panic" = "10";
 
         # Disable bpf() JIT (to eliminate spray attacks)
-        #"net.core.bpf_jit_enable" = mkDefault false;
+        #"net.core.bpf_jit_enable" = lib.mkDefault false;
 
         # ... or at least apply some hardening to it
         "net.core.bpf_jit_harden" = true;

--- a/modules/crypto.nix
+++ b/modules/crypto.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, utils, ... }:
 
-with lib;
-
 let
   cfg = config.settings.crypto;
 
@@ -11,35 +9,35 @@ let
     in
     { name, config, ... }: {
       options = {
-        enable = mkEnableOption "the encrypted device";
+        enable = lib.mkEnableOption "the encrypted device";
 
-        name = mkOption {
-          type = types.strMatching "^[[:lower:]][-_[:lower:]]+[[:lower:]]$";
+        name = lib.mkOption {
+          type = lib.types.strMatching "^[[:lower:]][-_[:lower:]]+[[:lower:]]$";
         };
 
-        device = mkOption {
-          type = types.str;
+        device = lib.mkOption {
+          type = lib.types.str;
           example = "/dev/LVMVolGroup/nixos_data";
           description = "The device to mount.";
         };
 
-        device_units = mkOption {
-          type = with types; listOf str;
+        device_units = lib.mkOption {
+          type = with lib.types; listOf str;
           default = [ ];
           example = [ "dev-disk-by\\x2did-dm\\x2dname\\x2dLVMVolGroup\\x2dnixos_data.device" ];
           description = "Device units to wait for or be triggered by.";
         };
 
-        key_file = mkOption {
-          type = types.str;
+        key_file = lib.mkOption {
+          type = lib.types.str;
           default = outerConfig.settings.crypto.defaultKeyFile;
           # We currently do not have multiple key files on any server and
           # we first need to migrate to properly secured key files.
           readOnly = true;
         };
 
-        mount_point = mkOption {
-          type = types.strMatching "^(/[-_[:lower:]]*)+$";
+        mount_point = lib.mkOption {
+          type = lib.types.strMatching "^(/[-_[:lower:]]*)+$";
           description = ''
             The mount point on which to mount the partition contained
             in this encrypted volume.
@@ -48,20 +46,20 @@ let
           '';
         };
 
-        filesystem_type = mkOption {
-          type = types.str;
+        filesystem_type = lib.mkOption {
+          type = lib.types.str;
           default = "ext4";
         };
 
-        mount_options = mkOption {
-          type = types.str;
+        mount_options = lib.mkOption {
+          type = lib.types.str;
           default = "";
           example = "acl,noatime,nosuid,nodev";
         };
       };
 
       config = {
-        name = mkDefault name;
+        name = lib.mkDefault name;
       };
     };
 in
@@ -72,16 +70,16 @@ in
       type = lib.types.str;
     };
 
-    mounts = mkOption {
-      type = with types; attrsOf (submodule cryptoOpts);
+    mounts = lib.mkOption {
+      type = with lib.types; attrsOf (submodule cryptoOpts);
       default = [ ];
     };
 
     encrypted_opt = {
-      enable = mkEnableOption "the encrypted /opt partition";
+      enable = lib.mkEnableOption "the encrypted /opt partition";
 
-      device = mkOption {
-        type = types.str;
+      device = lib.mkOption {
+        type = lib.types.str;
         default = "/dev/LVMVolGroup/nixos_data";
         description = "The device to mount on /opt.";
       };
@@ -89,8 +87,8 @@ in
   };
 
   imports = [
-    (mkRenamedOptionModule [ "settings" "crypto" "enable" ] [ "settings" "crypto" "encrypted_opt" "enable" ])
-    (mkRenamedOptionModule [ "settings" "crypto" "device" ] [ "settings" "crypto" "encrypted_opt" "device" ])
+    (lib.mkRenamedOptionModule [ "settings" "crypto" "enable" ] [ "settings" "crypto" "encrypted_opt" "enable" ])
+    (lib.mkRenamedOptionModule [ "settings" "crypto" "device" ] [ "settings" "crypto" "encrypted_opt" "device" ])
   ];
 
   config =
@@ -212,13 +210,13 @@ in
         ];
       };
 
-      mkOpenServices = mapAttrs' (_: conf: nameValuePair (open_service_name conf)
+      mkOpenServices = lib.mapAttrs' (_: conf: lib.nameValuePair (open_service_name conf)
         (mkOpenService conf));
-      mkMounts = mapAttrsToList (_: conf: mkMount conf);
+      mkMounts = lib.mapAttrsToList (_: conf: mkMount conf);
     in
     {
       settings.crypto.mounts = {
-        opt = mkIf cfg.encrypted_opt.enable {
+        opt = lib.mkIf cfg.encrypted_opt.enable {
           enable = true;
           inherit (cfg.encrypted_opt) device;
           mount_point = "/opt";
@@ -228,7 +226,7 @@ in
       systemd =
         let
           enabled = lib.filterEnabled cfg.mounts;
-          extra_mount_units = optional cfg.encrypted_opt.enable {
+          extra_mount_units = lib.optional cfg.encrypted_opt.enable {
             inherit (cfg.encrypted_opt) enable;
             what = "/opt/.home";
             where = "/home";

--- a/modules/network.nix
+++ b/modules/network.nix
@@ -1,26 +1,24 @@
 { config, lib, ... }:
 
-with lib;
-
 let
   cfg = config.settings.network;
 
   ifaceOpts = { name, ... }: {
     options = {
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = true;
       };
 
-      iface = mkOption {
-        type = types.str;
+      iface = lib.mkOption {
+        type = lib.types.str;
         description = ''
           Interface name, defaults to the name of this entry in the attribute set.
         '';
       };
 
-      fallback = mkOption {
-        type = types.bool;
+      fallback = lib.mkOption {
+        type = lib.types.bool;
         default = true;
         description = ''
           Select this static config only as a fallback in case DHCP fails.
@@ -28,20 +26,20 @@ let
         '';
       };
 
-      address = mkOption {
-        type = types.str;
+      address = lib.mkOption {
+        type = lib.types.str;
       };
 
-      prefix_length = mkOption {
-        type = types.ints.between 0 32;
+      prefix_length = lib.mkOption {
+        type = lib.types.ints.between 0 32;
       };
 
-      gateway = mkOption {
-        type = types.str;
+      gateway = lib.mkOption {
+        type = lib.types.str;
       };
 
-      nameservers = mkOption {
-        type = with types; listOf str;
+      nameservers = lib.mkOption {
+        type = with lib.types; listOf str;
         default = [ ];
         description = ''
           DNS servers which will be configured only when this static configuration is selected.
@@ -50,30 +48,30 @@ let
     };
 
     config = {
-      iface = mkDefault name;
+      iface = lib.mkDefault name;
     };
   };
 in
 {
   options = {
     settings.network = {
-      host_name = mkOption {
+      host_name = lib.mkOption {
         type = lib.types.host_name_type;
       };
 
-      static_ifaces = mkOption {
-        type = with types; attrsOf (submodule ifaceOpts);
+      static_ifaces = lib.mkOption {
+        type = with lib.types; attrsOf (submodule ifaceOpts);
         default = { };
       };
 
-      nameservers = mkOption {
-        type = with types; listOf str;
+      nameservers = lib.mkOption {
+        type = with lib.types; listOf str;
         default = [ ];
         description = "Globally defined DNS servers, in addition to those obtained by DHCP.";
       };
 
-      dhcpcd.enable = mkOption {
-        type = types.bool;
+      dhcpcd.enable = lib.mkOption {
+        type = lib.types.bool;
         default = true;
       };
     };
@@ -81,10 +79,10 @@ in
 
   config = {
     networking = {
-      hostName = mkForce cfg.host_name;
+      hostName = lib.mkForce cfg.host_name;
       # All non-manually configured interfaces are configured by DHCP.
       useDHCP = true;
-      dhcpcd = mkIf cfg.dhcpcd.enable (mkMerge [
+      dhcpcd = lib.mkIf cfg.dhcpcd.enable (lib.mkMerge [
         {
           persistent = true;
           # Per the manpage, interfaces matching these but also
@@ -95,7 +93,7 @@ in
           denyInterfaces = [ "eth*" "wlan*" "veth*" "docker*" ];
           extraConfig =
             let
-              format_name_servers = concatStringsSep " ";
+              format_name_servers = lib.concatStringsSep " ";
               mkConfig = _: conf:
                 if conf.fallback then ''
                   profile static_${conf.iface}
@@ -113,8 +111,8 @@ in
                   static domain_name_servers=${format_name_servers conf.nameservers}
                 '';
               mkConfigs = lib.compose [
-                (concatStringsSep "\n\n")
-                (mapAttrsToList mkConfig)
+                (lib.concatStringsSep "\n\n")
+                (lib.mapAttrsToList mkConfig)
                 lib.filterEnabled
               ];
             in

--- a/modules/nfs-client.nix
+++ b/modules/nfs-client.nix
@@ -1,15 +1,13 @@
 { config, lib, ... }:
 
-with lib;
-
 let
   cfg = config.nfs-client;
 in
 {
 
   options.nfs-client = {
-    mounts = mkOption {
-      type = types.attrsOf (types.attrsOf types.str);
+    mounts = lib.mkOption {
+      type = with lib.types; attrsOf (attrsOf str);
       default = { };
       description = ''
         List of NFS mounts configurations.

--- a/modules/nfs.nix
+++ b/modules/nfs.nix
@@ -1,7 +1,5 @@
 { config, pkgs, lib, ... }:
 
-#with lib;
-
 let
   cfg = config.settings.nfs;
 

--- a/modules/org_users.nix
+++ b/modules/org_users.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 let
   inherit (config.lib) ext_lib;
 
@@ -10,7 +8,7 @@ let
   addGroups = new_groups: role: role // {
     extraGroups =
       let
-        existing_groups = attrByPath [ "extraGroups" ] [ ] role;
+        existing_groups = lib.attrByPath [ "extraGroups" ] [ ] role;
       in
       existing_groups ++ new_groups;
   };
@@ -35,7 +33,7 @@ let
 
       # Admin users have shell access and belong to the wheel group
       admin = {
-        enable = mkDefault false;
+        enable = lib.mkDefault false;
         sshAllowed = true;
         hasShell = true;
         canTunnel = true;
@@ -47,14 +45,14 @@ let
       localDockerAdmin = addGroups [ "docker" ] localShell;
 
       remoteTunnelWithShell = {
-        enable = mkDefault false;
+        enable = lib.mkDefault false;
         sshAllowed = true;
         hasShell = true;
         canTunnel = true;
       };
 
       localShell = {
-        enable = mkDefault false;
+        enable = lib.mkDefault false;
         sshAllowed = true;
         hasShell = true;
         canTunnel = false;
@@ -62,7 +60,7 @@ let
 
       # Users who can tunnel only
       remoteTunnel = {
-        enable = mkDefault false;
+        enable = lib.mkDefault false;
         sshAllowed = true;
         hasShell = false;
         canTunnel = true;
@@ -126,10 +124,10 @@ in
   options = {
     settings.users = {
       robot = {
-        enable = mkEnableOption "the robot user";
+        enable = lib.mkEnableOption "the robot user";
 
-        username = mkOption {
-          type = types.str;
+        username = lib.mkOption {
+          type = lib.types.str;
           default = "robot";
           readOnly = true;
           description = ''
@@ -170,7 +168,7 @@ in
     users.users = {
       # Lock the root user
       root = {
-        hashedPassword = mkForce "!";
+        hashedPassword = lib.mkForce "!";
       };
     };
   };

--- a/modules/server-lock.nix
+++ b/modules/server-lock.nix
@@ -1,7 +1,5 @@
 { lib, config, pkgs, ... }:
 
-with lib;
-
 let
   cfg = config.settings.services.server-lock;
   crypto_cfg = config.settings.crypto;
@@ -11,35 +9,35 @@ in
 {
   options = {
     settings.services.server-lock = {
-      enable = mkEnableOption "the server lock service";
+      enable = lib.mkEnableOption "the server lock service";
 
-      listen_port = mkOption {
-        type = types.port;
+      listen_port = lib.mkOption {
+        type = lib.types.port;
         default = 1234;
       };
 
-      lock_retry_max_count = mkOption {
-        type = types.int;
+      lock_retry_max_count = lib.mkOption {
+        type = lib.types.int;
         default = 5;
       };
 
-      verify_retry_max_count = mkOption {
-        type = types.int;
+      verify_retry_max_count = lib.mkOption {
+        type = lib.types.int;
         default = 50;
       };
 
-      poll_interval = mkOption {
-        type = types.int;
+      poll_interval = lib.mkOption {
+        type = lib.types.int;
         default = 15;
       };
 
-      disable_targets = mkOption {
-        type = with types; listOf str;
+      disable_targets = lib.mkOption {
+        type = with lib.types; listOf str;
         default = [ "<localhost>" ];
       };
 
-      armed = mkOption {
-        type = types.bool;
+      armed = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether the server lock service is armed.
@@ -50,7 +48,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable (
+  config = lib.mkIf cfg.enable (
     let
       server-lock-user = "server-lock-button";
       mkScript = name: content:
@@ -75,14 +73,14 @@ in
                 ${pkgs.cryptsetup}/bin/cryptsetup luksRemoveKey ${device} ${key_file}
               '';
             in
-            mapAttrsToList (_: conf: mkDisable conf.device conf.key_file)
+            lib.mapAttrsToList (_: conf: mkDisable conf.device conf.key_file)
               crypto_cfg.mounts;
 
           rebootCommand = ''${pkgs.systemd}/bin/systemctl reboot'';
 
           wrapped =
             let
-              commands = concatStringsSep "\n" (disableKeyCommands ++ [ rebootCommand ]);
+              commands = lib.concatStringsSep "\n" (disableKeyCommands ++ [ rebootCommand ]);
             in
             mkScript wrapped_name commands;
 
@@ -111,9 +109,9 @@ in
                 fi
               '';
             in
-            mapAttrsToList (_: conf: mkVerify conf.mount_point) crypto_cfg.mounts;
+            lib.mapAttrsToList (_: conf: mkVerify conf.mount_point) crypto_cfg.mounts;
 
-          commands = concatStringsSep "\n" ([ verifyUptime ] ++ verifyMountPoints);
+          commands = lib.concatStringsSep "\n" ([ verifyUptime ] ++ verifyMountPoints);
 
         in
         mkScript script_name commands;
@@ -155,7 +153,7 @@ in
           script =
             let
               quoteString = s: ''"${s}"'';
-              formatTargets = concatMapStringsSep " " quoteString;
+              formatTargets = lib.concatMapStringsSep " " quoteString;
             in
             ''
               ${pkgs.nixos-server-lock}/bin/nixos_server_lock --listen_port ${toString cfg.listen_port} \

--- a/modules/system.nix
+++ b/modules/system.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, flakeInputs, ... }:
 
-with lib;
-
 let
   cfg = config.settings.system;
   tnl_cfg = config.settings.reverse_tunnel;
@@ -10,37 +8,37 @@ in
 
 {
   options.settings.system = {
-    isMbr = mkOption {
-      type = types.bool;
+    isMbr = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Does the machine boot from a disk with an MBR layout.
       '';
     };
 
-    isISO = mkOption {
-      type = types.bool;
+    isISO = lib.mkOption {
+      type = lib.types.bool;
       default = false;
     };
 
-    private_key_source = mkOption {
-      type = types.str;
+    private_key_source = lib.mkOption {
+      type = lib.types.str;
       default = "/var/lib/org-nix/id_tunnel";
       description = ''
         The location of the private key file used to establish the reverse tunnels.
       '';
     };
 
-    private_key_directory = mkOption {
-      type = types.str;
+    private_key_directory = lib.mkOption {
+      type = lib.types.str;
       default = "/run/tunnel";
       readOnly = true;
     };
 
     # It is crucial that this option has type str and not path,
     # to avoid the private key being copied into the nix store.
-    private_key = mkOption {
-      type = types.str;
+    private_key = lib.mkOption {
+      type = lib.types.str;
       default = "${cfg.private_key_directory}/id_tunnel";
       readOnly = true;
       description = ''
@@ -50,8 +48,8 @@ in
 
     # It is crucial that this option has type str and not path,
     # to avoid the private key being copied into the nix store.
-    github_private_key = mkOption {
-      type = types.str;
+    github_private_key = lib.mkOption {
+      type = lib.types.str;
       default = "${cfg.private_key_directory}/id_github";
       description = ''
         Location to load the private key file for GitHub from.
@@ -59,8 +57,8 @@ in
     };
 
     org = {
-      config_dir_name = mkOption {
-        type = types.str;
+      config_dir_name = lib.mkOption {
+        type = lib.types.str;
         default = "org-config";
         readOnly = true;
         description = ''
@@ -69,42 +67,42 @@ in
         '';
       };
 
-      env_var_prefix = mkOption {
-        type = types.str;
+      env_var_prefix = lib.mkOption {
+        type = lib.types.str;
       };
 
-      github_org = mkOption {
-        type = types.str;
+      github_org = lib.mkOption {
+        type = lib.types.str;
       };
 
-      repo_to_url = mkOption {
-        type = with types; functionTo str;
+      repo_to_url = lib.mkOption {
+        type = with lib.types; functionTo str;
         default = repo: ''git+ssh://git@github.com/${cfg.org.github_org}/${repo}.git'';
       };
 
       iso = {
-        menu_label = mkOption {
-          type = types.str;
+        menu_label = lib.mkOption {
+          type = lib.types.str;
           default = "NixOS Rescue System";
         };
 
-        file_label = mkOption {
-          type = types.str;
+        file_label = lib.mkOption {
+          type = lib.types.str;
           default = "nixos-rescue";
         };
       };
     };
 
-    users_json_path = mkOption {
-      type = types.path;
+    users_json_path = lib.mkOption {
+      type = lib.types.path;
     };
 
-    keys_json_path = mkOption {
-      type = types.path;
+    keys_json_path = lib.mkOption {
+      type = lib.types.path;
     };
 
-    tunnels_json_dir_path = mkOption {
-      type = with types; nullOr path;
+    tunnels_json_dir_path = lib.mkOption {
+      type = with lib.types; nullOr path;
     };
 
     secrets = {
@@ -113,35 +111,35 @@ in
         default = config.networking.hostName;
       };
 
-      src_directory = mkOption {
-        type = types.path;
+      src_directory = lib.mkOption {
+        type = lib.types.path;
         description = ''
           The directory containing the generated and encrypted secrets.
         '';
       };
 
-      src_file = mkOption {
-        type = types.path;
+      src_file = lib.mkOption {
+        type = lib.types.path;
         default = cfg.secrets.src_directory + "/generated-secrets.yml";
         description = ''
           The file containing the generated and encrypted secrets.
         '';
       };
 
-      dest_directory = mkOption {
-        type = types.str;
+      dest_directory = lib.mkOption {
+        type = lib.types.str;
         description = ''
           The directory containing the decrypted secrets available to this server.
         '';
       };
 
-      old_dest_directories = mkOption {
-        type = with types; listOf str;
+      old_dest_directories = lib.mkOption {
+        type = with lib.types; listOf str;
         default = [ ];
       };
 
-      allow_groups = mkOption {
-        type = with types; listOf str;
+      allow_groups = lib.mkOption {
+        type = with lib.types; listOf str;
         description = ''
           Groups which have access to the secrets through ACLs.
         '';
@@ -150,30 +148,30 @@ in
     };
 
     app_configs = {
-      src_directory = mkOption {
-        type = types.path;
+      src_directory = lib.mkOption {
+        type = lib.types.path;
         description = ''
           The directory containing the generated app configs.
         '';
       };
 
-      src_file = mkOption {
-        type = types.path;
+      src_file = lib.mkOption {
+        type = lib.types.path;
         default = cfg.app_configs.src_directory + "/generated-app-configs.yml";
         description = ''
           The file containing the generated app configs.
         '';
       };
 
-      dest_directory = mkOption {
-        type = types.str;
+      dest_directory = lib.mkOption {
+        type = lib.types.str;
         description = ''
           The directory containing the app configs available to this server.
         '';
       };
 
-      allow_groups = mkOption {
-        type = with types; listOf str;
+      allow_groups = lib.mkOption {
+        type = with lib.types; listOf str;
         description = ''
           Groups which have access to the app configs through ACLs.
         '';
@@ -182,13 +180,13 @@ in
     };
 
     opt = {
-      allow_groups = mkOption {
-        type = with types; listOf str;
+      allow_groups = lib.mkOption {
+        type = with lib.types; listOf str;
       };
     };
     secrets = {
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = true;
       };
     };
@@ -231,7 +229,7 @@ in
 
     assertions = [
       {
-        assertion = hasAttr config.networking.hostName tnl_cfg.tunnels;
+        assertion = lib.hasAttr config.networking.hostName tnl_cfg.tunnels;
         message =
           "This host's host name is not present in the tunnel config " +
           "(${toString cfg.tunnels_json_dir_path}).";
@@ -255,15 +253,15 @@ in
     # mkForce has a priority of 50, while the default priority is 100.
     # We use 75 here to override the setting in hardware-configuration.nix files
     # that were generated with old versions of nixos-generate-config that did
-    # not yet use mkDefault, but we also still want to allow the usage of mkForce.
-    powerManagement.cpuFreqGovernor = mkOverride 75 "schedutil";
+    # not yet use lib.mkDefault, but we also still want to allow the usage of mkForce.
+    powerManagement.cpuFreqGovernor = lib.mkOverride 75 "schedutil";
 
     security = {
       sudo = {
         enable = true;
         wheelNeedsPassword = false;
       };
-      pam.services.su.forwardXAuth = mkForce false;
+      pam.services.su.forwardXAuth = lib.mkForce false;
     };
 
     environment = {
@@ -279,7 +277,7 @@ in
           let
             hash = builtins.hashString "sha256" config.networking.hostName;
           in
-          substring 0 12 hash;
+          lib.substring 0 12 hash;
         "${cfg.org.env_var_prefix}_SECRETS_DIRECTORY" = cfg.secrets.dest_directory;
         "${cfg.org.env_var_prefix}_CONFIGS_DIRECTORY" = cfg.app_configs.dest_directory;
       };
@@ -425,7 +423,7 @@ in
                 # from the ACLs on files, but this currently does not seem worth it,
                 # given the additional complexity that this would introduce in this
                 # script.
-                acl = concatStringsSep "," (
+                acl = lib.concatStringsSep "," (
                   [
                     "u::rwX"
                     "user:root:rwX"
@@ -434,11 +432,11 @@ in
                     "d:o::---"
                     "d:user:root:rwx"
                   ] ++
-                  concatMap (group: [ "group:${group}:rwX" "d:group:${group}:rwx" ])
+                  lib.concatMap (group: [ "group:${group}:rwX" "d:group:${group}:rwx" ])
                     cfg.opt.allow_groups
                 );
                 # For /opt we use setfacl --set, so we need to define the full ACL
-                opt_acl = concatStringsSep "," [ "g::r-X" "o::---" acl ];
+                opt_acl = lib.concatStringsSep "," [ "g::r-X" "o::---" acl ];
               in
               ''
                 # Ensure that /opt actually exists
@@ -505,7 +503,7 @@ in
             script =
               let
                 base_files = [ cfg.private_key_source legacy_key_path ];
-                files = concatStringsSep " " (unique (concatMap (f: [ f "${f}.pub" ]) base_files));
+                files = lib.concatStringsSep " " (lib.unique (lib.concatMap (f: [ f "${f}.pub" ]) base_files));
               in
               ''
                 for file in ${files}; do
@@ -583,7 +581,7 @@ in
               let
                 # We make an ACL with default permissions and add an extra rule
                 # for each group defined as having access
-                acl = concatStringsSep "," (
+                acl = lib.concatStringsSep "," (
                   [ "u::rwX,g::r-X,o::---" ] ++ map (group: "group:${group}:rX") cfg.secrets.allow_groups
                 );
                 mkRemoveOldDir = dir: ''
@@ -600,7 +598,7 @@ in
               in
               ''
                 echo "decrypting the server secrets..."
-                ${concatMapStringsSep "\n" mkRemoveOldDir cfg.secrets.old_dest_directories}
+                ${lib.concatMapStringsSep "\n" mkRemoveOldDir cfg.secrets.old_dest_directories}
                 if [ -e "${cfg.secrets.dest_directory}" ]; then
                   ${pkgs.coreutils}/bin/rm --one-file-system \
                                            --recursive \
@@ -635,7 +633,7 @@ in
               let
                 # We make an ACL with default permissions and add an extra rule
                 # for each group defined as having access
-                acl = concatStringsSep "," (
+                acl = lib.concatStringsSep "," (
                   [ "u::rwX,g::r-X,o::---" ] ++ map (group: "group:${group}:rX") cfg.app_configs.allow_groups
                 );
               in
@@ -695,7 +693,7 @@ in
     };
 
     # No fonts needed on a headless system
-    fonts.fontconfig.enable = mkForce false;
+    fonts.fontconfig.enable = lib.mkForce false;
 
     programs = {
       bash.enableCompletion = true;
@@ -752,7 +750,7 @@ in
 
       timesyncd = {
         enable = lib.mkDefault true;
-        servers = mkDefault [
+        servers = lib.mkDefault [
           "0.nixos.pool.ntp.org"
           "1.nixos.pool.ntp.org"
           "2.nixos.pool.ntp.org"

--- a/modules/traefik.nix
+++ b/modules/traefik.nix
@@ -1,7 +1,5 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
 #
 # **** NOTE
 #
@@ -23,100 +21,100 @@ in
     let
       tls_entrypoint_opts = { name, ... }: {
         options = {
-          name = mkOption {
-            type = types.str;
+          name = lib.mkOption {
+            type = lib.types.str;
           };
 
-          enable = mkEnableOption "the user";
+          enable = lib.mkEnableOption "the user";
 
-          host = mkOption {
-            type = types.str;
+          host = lib.mkOption {
+            type = lib.types.str;
             default = "";
           };
 
-          port = mkOption {
-            type = types.port;
+          port = lib.mkOption {
+            type = lib.types.port;
           };
 
         };
         config = {
-          name = mkDefault name;
+          name = lib.mkDefault name;
         };
       };
     in
     {
-      enable = mkEnableOption "the Traefik service";
+      enable = lib.mkEnableOption "the Traefik service";
 
-      version = mkOption {
-        type = types.str;
+      version = lib.mkOption {
+        type = lib.types.str;
         default = "3.3";
       };
 
-      image = mkOption {
-        type = types.str;
+      image = lib.mkOption {
+        type = lib.types.str;
         default = "traefik";
         readOnly = true;
       };
-      encode_semicolons = mkOption {
-        type = types.bool;
+      encode_semicolons = lib.mkOption {
+        type = lib.types.bool;
         default = false;
       };
 
       # Enable the SMTP entrypoint, which is used for sending emails
 
-      smqtt_enable = mkEnableOption "SMQTT";
+      smqtt_enable = lib.mkEnableOption "SMQTT";
 
-      smtp_enable = mkEnableOption "SMTP";
+      smtp_enable = lib.mkEnableOption "SMTP";
 
-      service_name = mkOption {
-        type = types.str;
+      service_name = lib.mkOption {
+        type = lib.types.str;
         default = "nixos-traefik";
         readOnly = true;
       };
 
-      dynamic_config = mkOption {
-        type = with types; attrsOf (submodule {
+      dynamic_config = lib.mkOption {
+        type = with lib.types; attrsOf (submodule {
           options = {
-            enable = mkOption {
-              type = types.bool;
+            enable = lib.mkOption {
+              type = lib.types.bool;
               default = true;
             };
-            value = mkOption {
+            value = lib.mkOption {
               inherit (yaml_format) type;
             };
           };
         });
       };
 
-      tls_entrypoints = mkOption {
-        type = with types; attrsOf (submodule tls_entrypoint_opts);
+      tls_entrypoints = lib.mkOption {
+        type = with lib.types; attrsOf (submodule tls_entrypoint_opts);
         default = { };
       };
 
-      network_name = mkOption {
-        type = types.str;
+      network_name = lib.mkOption {
+        type = lib.types.str;
         default = "web";
       };
 
-      logging_level = mkOption {
-        type = types.enum [ "INFO" "DEBUG" "TRACE" ];
+      logging_level = lib.mkOption {
+        type = lib.types.enum [ "INFO" "DEBUG" "TRACE" ];
         default = "INFO";
       };
 
       accesslog = {
-        enable = mkOption {
-          type = types.bool;
+        enable = lib.mkOption {
+          type = lib.types.bool;
           default = true;
         };
       };
 
-      traefik_entrypoint_port = mkOption {
-        type = types.port;
+      traefik_entrypoint_port = lib.mkOption {
+        type = lib.types.port;
         default = 8080;
       };
 
-      content_type_nosniff_enable = mkOption {
-        type = types.bool;
+      content_type_nosniff_enable = lib.mkOption {
+        type = lib.types.bool;
         default = true;
       };
 
@@ -129,22 +127,22 @@ in
             else null;
         };
 
-        staging.enable = mkEnableOption "the Let's Encrypt staging environment";
+        staging.enable = lib.mkEnableOption "the Let's Encrypt staging environment";
 
-        keytype = mkOption {
-          type = types.str;
+        keytype = lib.mkOption {
+          type = lib.types.str;
           default = "EC256";
           readOnly = true;
         };
 
-        storage = mkOption {
-          type = types.str;
+        storage = lib.mkOption {
+          type = lib.types.str;
           default = "/letsencrypt";
           readOnly = true;
         };
 
-        email_address = mkOption {
-          type = types.str;
+        email_address = lib.mkOption {
+          type = lib.types.str;
         };
 
         resolvers = lib.mkOption {
@@ -170,14 +168,14 @@ in
           default = [ ];
         };
 
-        dnsProviders = mkOption {
-          type = with types; attrsOf str;
+        dnsProviders = lib.mkOption {
+          type = with lib.types; attrsOf str;
           default = { azure = "azure"; route53 = "route53"; exec = "exec"; };
           readOnly = true;
         };
 
-        dnsProvider = mkOption {
-          type = types.enum (attrValues cfg.acme.dnsProviders);
+        dnsProvider = lib.mkOption {
+          type = lib.types.enum (lib.attrValues cfg.acme.dnsProviders);
         };
       };
 
@@ -210,7 +208,7 @@ in
       # https://github.com/traefik/traefik/issues/6636
       dashboard-middleware = "dashboard-middleware";
     in
-    mkIf cfg.enable {
+    lib.mkIf cfg.enable {
 
       assertions = [{
         assertion = config.virtualisation.docker.enable;
@@ -302,11 +300,11 @@ in
             static_config_file_source =
               let
                 generate_tls_entrypoints = lib.compose [
-                  (mapAttrs (_: value: { address = "${value.host}:${toString value.port}"; }))
+                  (lib.mapAttrs (_: value: { address = "${value.host}:${toString value.port}"; }))
                   lib.filterEnabled
                 ];
                 letsencrypt = "letsencrypt";
-                caserver = optionalAttrs (cfg.acme.caServer != null)
+                caserver = lib.optionalAttrs (cfg.acme.caServer != null)
                   { inherit (cfg.acme) caServer; };
                 acme_template = {
                   email = cfg.acme.email_address;
@@ -318,7 +316,7 @@ in
                       cfg.acme.extraCaCertificateFiles
                   );
                 } // caserver;
-                accesslog = optionalAttrs cfg.accesslog.enable {
+                accesslog = lib.optionalAttrs cfg.accesslog.enable {
                   accessLog = {
                     # Make sure that the times are printed in local time
                     # https://doc.traefik.io/traefik/observability/access-logs/#time-zones
@@ -412,7 +410,7 @@ in
                     file = yaml_format.generate name configFile.value;
                   in
                   "${file}:${dynamic_config_directory_target}/${name}:ro";
-                buildConfigFiles = mapAttrsToList buildConfigFile;
+                buildConfigFiles = lib.mapAttrsToList buildConfigFile;
               in
               lib.compose [
                 buildConfigFiles
@@ -435,7 +433,7 @@ in
                       port = toString cfg.port;
                     in
                     "${port}:${port}";
-                  mk_tls_ports = mapAttrsToList (_: mk_tls_port);
+                  mk_tls_ports = lib.mapAttrsToList (_: mk_tls_port);
                 in
                 [
                   "80:80"

--- a/modules/vmware.nix
+++ b/modules/vmware.nix
@@ -4,19 +4,17 @@ let
   cfg = config.settings.vmware;
 in
 
-with lib;
-
 {
   options.settings.vmware = {
-    enable = mkEnableOption "the VMWare guest services";
+    enable = lib.mkEnableOption "the VMWare guest services";
 
-    inDMZ = mkOption {
-      type = types.bool;
+    inDMZ = lib.mkOption {
+      type = lib.types.bool;
       default = false;
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     settings = {
       hardwarePlatform = config.settings.hardwarePlatforms.vmware;
 
@@ -27,7 +25,7 @@ with lib;
       maintenance.nixos_upgrade.startAt = [ "Tue 03:00" ];
     };
 
-    services.timesyncd.servers = mkIf (!cfg.inDMZ) [ "172.16.0.101" ];
+    services.timesyncd.servers = lib.mkIf (!cfg.inDMZ) [ "172.16.0.101" ];
 
     networking.nameservers =
       if cfg.inDMZ

--- a/org-config/deployment_services.nix
+++ b/org-config/deployment_services.nix
@@ -1,7 +1,5 @@
 { config, lib, ... }:
 
-with lib;
-
 let
   inherit (config.lib) ext_lib;
 
@@ -11,7 +9,7 @@ in
 {
   options.settings.services.deployment_services = {
     update_demo_app_config.enable =
-      mkEnableOption "the update_demo_app_config service";
+      lib.mkEnableOption "the update_demo_app_config service";
 
   };
 
@@ -44,8 +42,8 @@ in
             ext_lib.mkSudoStartServiceCmds { inherit serviceName; };
         in
         lib.compose [
-          (concatMap mkStartCmds)
-          attrNames
+          (lib.concatMap mkStartCmds)
+          lib.attrNames
         ]
           enabled_deployment_services;
     };


### PR DESCRIPTION
The Nix code was a mix of explicit and implicit addressing of lib functions.

This change removes all use of `with lib;` and makes all the functions explicit in scope.