### PR TITLE
feat: add example custom templates for oauth2-proxy

### DIFF
--- a/oauth2-proxy-templates/README.md
+++ b/oauth2-proxy-templates/README.md
@@ -1,0 +1,5 @@
+# oauth2-proxy-templates
+
+The documentation is lacking, but this issue explains the basics of applying the custom templates: https://github.com/oauth2-proxy/oauth2-proxy/issues/1507.
+
+These templates are untested.

--- a/oauth2-proxy-templates/all.min.css
+++ b/oauth2-proxy-templates/all.min.css
@@ -1,0 +1,6957 @@
+/*!
+ * Font Awesome Free 6.3.0 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
+ * Copyright 2023 Fonticons, Inc.
+ */
+.fa {
+  font-family: var(--fa-style-family, "Font Awesome 6 Free");
+  font-weight: var(--fa-style, 900);
+}
+.fa,
+.fa-brands,
+.fa-classic,
+.fa-regular,
+.fa-sharp,
+.fa-solid,
+.fab,
+.far,
+.fas {
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: var(--fa-display, inline-block);
+  font-style: normal;
+  font-variant: normal;
+  line-height: 1;
+  text-rendering: auto;
+}
+.fa-classic,
+.fa-regular,
+.fa-solid,
+.far,
+.fas {
+  font-family: "Font Awesome 6 Free";
+}
+.fa-brands,
+.fab {
+  font-family: "Font Awesome 6 Brands";
+}
+.fa-1x {
+  font-size: 1em;
+}
+.fa-2x {
+  font-size: 2em;
+}
+.fa-3x {
+  font-size: 3em;
+}
+.fa-4x {
+  font-size: 4em;
+}
+.fa-5x {
+  font-size: 5em;
+}
+.fa-6x {
+  font-size: 6em;
+}
+.fa-7x {
+  font-size: 7em;
+}
+.fa-8x {
+  font-size: 8em;
+}
+.fa-9x {
+  font-size: 9em;
+}
+.fa-10x {
+  font-size: 10em;
+}
+.fa-2xs {
+  font-size: 0.625em;
+  line-height: 0.1em;
+  vertical-align: 0.225em;
+}
+.fa-xs {
+  font-size: 0.75em;
+  line-height: 0.08333em;
+  vertical-align: 0.125em;
+}
+.fa-sm {
+  font-size: 0.875em;
+  line-height: 0.07143em;
+  vertical-align: 0.05357em;
+}
+.fa-lg {
+  font-size: 1.25em;
+  line-height: 0.05em;
+  vertical-align: -0.075em;
+}
+.fa-xl {
+  font-size: 1.5em;
+  line-height: 0.04167em;
+  vertical-align: -0.125em;
+}
+.fa-2xl {
+  font-size: 2em;
+  line-height: 0.03125em;
+  vertical-align: -0.1875em;
+}
+.fa-fw {
+  text-align: center;
+  width: 1.25em;
+}
+.fa-ul {
+  list-style-type: none;
+  margin-left: var(--fa-li-margin, 2.5em);
+  padding-left: 0;
+}
+.fa-ul > li {
+  position: relative;
+}
+.fa-li {
+  left: calc(var(--fa-li-width, 2em) * -1);
+  position: absolute;
+  text-align: center;
+  width: var(--fa-li-width, 2em);
+  line-height: inherit;
+}
+.fa-border {
+  border-radius: var(--fa-border-radius, 0.1em);
+  border: var(--fa-border-width, 0.08em) var(--fa-border-style, solid)
+    var(--fa-border-color, #eee);
+  padding: var(--fa-border-padding, 0.2em 0.25em 0.15em);
+}
+.fa-pull-left {
+  float: left;
+  margin-right: var(--fa-pull-margin, 0.3em);
+}
+.fa-pull-right {
+  float: right;
+  margin-left: var(--fa-pull-margin, 0.3em);
+}
+.fa-beat {
+  -webkit-animation-name: fa-beat;
+  animation-name: fa-beat;
+  -webkit-animation-delay: var(--fa-animation-delay, 0s);
+  animation-delay: var(--fa-animation-delay, 0s);
+  -webkit-animation-direction: var(--fa-animation-direction, normal);
+  animation-direction: var(--fa-animation-direction, normal);
+  -webkit-animation-duration: var(--fa-animation-duration, 1s);
+  animation-duration: var(--fa-animation-duration, 1s);
+  -webkit-animation-iteration-count: var(
+    --fa-animation-iteration-count,
+    infinite
+  );
+  animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+  -webkit-animation-timing-function: var(--fa-animation-timing, ease-in-out);
+  animation-timing-function: var(--fa-animation-timing, ease-in-out);
+}
+.fa-bounce {
+  -webkit-animation-name: fa-bounce;
+  animation-name: fa-bounce;
+  -webkit-animation-delay: var(--fa-animation-delay, 0s);
+  animation-delay: var(--fa-animation-delay, 0s);
+  -webkit-animation-direction: var(--fa-animation-direction, normal);
+  animation-direction: var(--fa-animation-direction, normal);
+  -webkit-animation-duration: var(--fa-animation-duration, 1s);
+  animation-duration: var(--fa-animation-duration, 1s);
+  -webkit-animation-iteration-count: var(
+    --fa-animation-iteration-count,
+    infinite
+  );
+  animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+  -webkit-animation-timing-function: var(
+    --fa-animation-timing,
+    cubic-bezier(0.28, 0.84, 0.42, 1)
+  );
+  animation-timing-function: var(
+    --fa-animation-timing,
+    cubic-bezier(0.28, 0.84, 0.42, 1)
+  );
+}
+.fa-fade {
+  -webkit-animation-name: fa-fade;
+  animation-name: fa-fade;
+  -webkit-animation-iteration-count: var(
+    --fa-animation-iteration-count,
+    infinite
+  );
+  animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+  -webkit-animation-timing-function: var(
+    --fa-animation-timing,
+    cubic-bezier(0.4, 0, 0.6, 1)
+  );
+  animation-timing-function: var(
+    --fa-animation-timing,
+    cubic-bezier(0.4, 0, 0.6, 1)
+  );
+}
+.fa-beat-fade,
+.fa-fade {
+  -webkit-animation-delay: var(--fa-animation-delay, 0s);
+  animation-delay: var(--fa-animation-delay, 0s);
+  -webkit-animation-direction: var(--fa-animation-direction, normal);
+  animation-direction: var(--fa-animation-direction, normal);
+  -webkit-animation-duration: var(--fa-animation-duration, 1s);
+  animation-duration: var(--fa-animation-duration, 1s);
+}
+.fa-beat-fade {
+  -webkit-animation-name: fa-beat-fade;
+  animation-name: fa-beat-fade;
+  -webkit-animation-iteration-count: var(
+    --fa-animation-iteration-count,
+    infinite
+  );
+  animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+  -webkit-animation-timing-function: var(
+    --fa-animation-timing,
+    cubic-bezier(0.4, 0, 0.6, 1)
+  );
+  animation-timing-function: var(
+    --fa-animation-timing,
+    cubic-bezier(0.4, 0, 0.6, 1)
+  );
+}
+.fa-flip {
+  -webkit-animation-name: fa-flip;
+  animation-name: fa-flip;
+  -webkit-animation-delay: var(--fa-animation-delay, 0s);
+  animation-delay: var(--fa-animation-delay, 0s);
+  -webkit-animation-direction: var(--fa-animation-direction, normal);
+  animation-direction: var(--fa-animation-direction, normal);
+  -webkit-animation-duration: var(--fa-animation-duration, 1s);
+  animation-duration: var(--fa-animation-duration, 1s);
+  -webkit-animation-iteration-count: var(
+    --fa-animation-iteration-count,
+    infinite
+  );
+  animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+  -webkit-animation-timing-function: var(--fa-animation-timing, ease-in-out);
+  animation-timing-function: var(--fa-animation-timing, ease-in-out);
+}
+.fa-shake {
+  -webkit-animation-name: fa-shake;
+  animation-name: fa-shake;
+  -webkit-animation-duration: var(--fa-animation-duration, 1s);
+  animation-duration: var(--fa-animation-duration, 1s);
+  -webkit-animation-iteration-count: var(
+    --fa-animation-iteration-count,
+    infinite
+  );
+  animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+  -webkit-animation-timing-function: var(--fa-animation-timing, linear);
+  animation-timing-function: var(--fa-animation-timing, linear);
+}
+.fa-shake,
+.fa-spin {
+  -webkit-animation-delay: var(--fa-animation-delay, 0s);
+  animation-delay: var(--fa-animation-delay, 0s);
+  -webkit-animation-direction: var(--fa-animation-direction, normal);
+  animation-direction: var(--fa-animation-direction, normal);
+}
+.fa-spin {
+  -webkit-animation-name: fa-spin;
+  animation-name: fa-spin;
+  -webkit-animation-duration: var(--fa-animation-duration, 2s);
+  animation-duration: var(--fa-animation-duration, 2s);
+  -webkit-animation-iteration-count: var(
+    --fa-animation-iteration-count,
+    infinite
+  );
+  animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+  -webkit-animation-timing-function: var(--fa-animation-timing, linear);
+  animation-timing-function: var(--fa-animation-timing, linear);
+}
+.fa-spin-reverse {
+  --fa-animation-direction: reverse;
+}
+.fa-pulse,
+.fa-spin-pulse {
+  -webkit-animation-name: fa-spin;
+  animation-name: fa-spin;
+  -webkit-animation-direction: var(--fa-animation-direction, normal);
+  animation-direction: var(--fa-animation-direction, normal);
+  -webkit-animation-duration: var(--fa-animation-duration, 1s);
+  animation-duration: var(--fa-animation-duration, 1s);
+  -webkit-animation-iteration-count: var(
+    --fa-animation-iteration-count,
+    infinite
+  );
+  animation-iteration-count: var(--fa-animation-iteration-count, infinite);
+  -webkit-animation-timing-function: var(--fa-animation-timing, steps(8));
+  animation-timing-function: var(--fa-animation-timing, steps(8));
+}
+@media (prefers-reduced-motion: reduce) {
+  .fa-beat,
+  .fa-beat-fade,
+  .fa-bounce,
+  .fa-fade,
+  .fa-flip,
+  .fa-pulse,
+  .fa-shake,
+  .fa-spin,
+  .fa-spin-pulse {
+    -webkit-animation-delay: -1ms;
+    animation-delay: -1ms;
+    -webkit-animation-duration: 1ms;
+    animation-duration: 1ms;
+    -webkit-animation-iteration-count: 1;
+    animation-iteration-count: 1;
+    -webkit-transition-delay: 0s;
+    transition-delay: 0s;
+    -webkit-transition-duration: 0s;
+    transition-duration: 0s;
+  }
+}
+@-webkit-keyframes fa-beat {
+  0%,
+  90% {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+  }
+  45% {
+    -webkit-transform: scale(var(--fa-beat-scale, 1.25));
+    transform: scale(var(--fa-beat-scale, 1.25));
+  }
+}
+@keyframes fa-beat {
+  0%,
+  90% {
+    -webkit-transform: scale(1);
+    transform: scale(1);
+  }
+  45% {
+    -webkit-transform: scale(var(--fa-beat-scale, 1.25));
+    transform: scale(var(--fa-beat-scale, 1.25));
+  }
+}
+@-webkit-keyframes fa-bounce {
+  0% {
+    -webkit-transform: scale(1) translateY(0);
+    transform: scale(1) translateY(0);
+  }
+  10% {
+    -webkit-transform: scale(
+        var(--fa-bounce-start-scale-x, 1.1),
+        var(--fa-bounce-start-scale-y, 0.9)
+      )
+      translateY(0);
+    transform: scale(
+        var(--fa-bounce-start-scale-x, 1.1),
+        var(--fa-bounce-start-scale-y, 0.9)
+      )
+      translateY(0);
+  }
+  30% {
+    -webkit-transform: scale(
+        var(--fa-bounce-jump-scale-x, 0.9),
+        var(--fa-bounce-jump-scale-y, 1.1)
+      )
+      translateY(var(--fa-bounce-height, -0.5em));
+    transform: scale(
+        var(--fa-bounce-jump-scale-x, 0.9),
+        var(--fa-bounce-jump-scale-y, 1.1)
+      )
+      translateY(var(--fa-bounce-height, -0.5em));
+  }
+  50% {
+    -webkit-transform: scale(
+        var(--fa-bounce-land-scale-x, 1.05),
+        var(--fa-bounce-land-scale-y, 0.95)
+      )
+      translateY(0);
+    transform: scale(
+        var(--fa-bounce-land-scale-x, 1.05),
+        var(--fa-bounce-land-scale-y, 0.95)
+      )
+      translateY(0);
+  }
+  57% {
+    -webkit-transform: scale(1) translateY(var(--fa-bounce-rebound, -0.125em));
+    transform: scale(1) translateY(var(--fa-bounce-rebound, -0.125em));
+  }
+  64% {
+    -webkit-transform: scale(1) translateY(0);
+    transform: scale(1) translateY(0);
+  }
+  to {
+    -webkit-transform: scale(1) translateY(0);
+    transform: scale(1) translateY(0);
+  }
+}
+@keyframes fa-bounce {
+  0% {
+    -webkit-transform: scale(1) translateY(0);
+    transform: scale(1) translateY(0);
+  }
+  10% {
+    -webkit-transform: scale(
+        var(--fa-bounce-start-scale-x, 1.1),
+        var(--fa-bounce-start-scale-y, 0.9)
+      )
+      translateY(0);
+    transform: scale(
+        var(--fa-bounce-start-scale-x, 1.1),
+        var(--fa-bounce-start-scale-y, 0.9)
+      )
+      translateY(0);
+  }
+  30% {
+    -webkit-transform: scale(
+        var(--fa-bounce-jump-scale-x, 0.9),
+        var(--fa-bounce-jump-scale-y, 1.1)
+      )
+      translateY(var(--fa-bounce-height, -0.5em));
+    transform: scale(
+        var(--fa-bounce-jump-scale-x, 0.9),
+        var(--fa-bounce-jump-scale-y, 1.1)
+      )
+      translateY(var(--fa-bounce-height, -0.5em));
+  }
+  50% {
+    -webkit-transform: scale(
+        var(--fa-bounce-land-scale-x, 1.05),
+        var(--fa-bounce-land-scale-y, 0.95)
+      )
+      translateY(0);
+    transform: scale(
+        var(--fa-bounce-land-scale-x, 1.05),
+        var(--fa-bounce-land-scale-y, 0.95)
+      )
+      translateY(0);
+  }
+  57% {
+    -webkit-transform: scale(1) translateY(var(--fa-bounce-rebound, -0.125em));
+    transform: scale(1) translateY(var(--fa-bounce-rebound, -0.125em));
+  }
+  64% {
+    -webkit-transform: scale(1) translateY(0);
+    transform: scale(1) translateY(0);
+  }
+  to {
+    -webkit-transform: scale(1) translateY(0);
+    transform: scale(1) translateY(0);
+  }
+}
+@-webkit-keyframes fa-fade {
+  50% {
+    opacity: var(--fa-fade-opacity, 0.4);
+  }
+}
+@keyframes fa-fade {
+  50% {
+    opacity: var(--fa-fade-opacity, 0.4);
+  }
+}
+@-webkit-keyframes fa-beat-fade {
+  0%,
+  to {
+    opacity: var(--fa-beat-fade-opacity, 0.4);
+    -webkit-transform: scale(1);
+    transform: scale(1);
+  }
+  50% {
+    opacity: 1;
+    -webkit-transform: scale(var(--fa-beat-fade-scale, 1.125));
+    transform: scale(var(--fa-beat-fade-scale, 1.125));
+  }
+}
+@keyframes fa-beat-fade {
+  0%,
+  to {
+    opacity: var(--fa-beat-fade-opacity, 0.4);
+    -webkit-transform: scale(1);
+    transform: scale(1);
+  }
+  50% {
+    opacity: 1;
+    -webkit-transform: scale(var(--fa-beat-fade-scale, 1.125));
+    transform: scale(var(--fa-beat-fade-scale, 1.125));
+  }
+}
+@-webkit-keyframes fa-flip {
+  50% {
+    -webkit-transform: rotate3d(
+      var(--fa-flip-x, 0),
+      var(--fa-flip-y, 1),
+      var(--fa-flip-z, 0),
+      var(--fa-flip-angle, -180deg)
+    );
+    transform: rotate3d(
+      var(--fa-flip-x, 0),
+      var(--fa-flip-y, 1),
+      var(--fa-flip-z, 0),
+      var(--fa-flip-angle, -180deg)
+    );
+  }
+}
+@keyframes fa-flip {
+  50% {
+    -webkit-transform: rotate3d(
+      var(--fa-flip-x, 0),
+      var(--fa-flip-y, 1),
+      var(--fa-flip-z, 0),
+      var(--fa-flip-angle, -180deg)
+    );
+    transform: rotate3d(
+      var(--fa-flip-x, 0),
+      var(--fa-flip-y, 1),
+      var(--fa-flip-z, 0),
+      var(--fa-flip-angle, -180deg)
+    );
+  }
+}
+@-webkit-keyframes fa-shake {
+  0% {
+    -webkit-transform: rotate(-15deg);
+    transform: rotate(-15deg);
+  }
+  4% {
+    -webkit-transform: rotate(15deg);
+    transform: rotate(15deg);
+  }
+  8%,
+  24% {
+    -webkit-transform: rotate(-18deg);
+    transform: rotate(-18deg);
+  }
+  12%,
+  28% {
+    -webkit-transform: rotate(18deg);
+    transform: rotate(18deg);
+  }
+  16% {
+    -webkit-transform: rotate(-22deg);
+    transform: rotate(-22deg);
+  }
+  20% {
+    -webkit-transform: rotate(22deg);
+    transform: rotate(22deg);
+  }
+  32% {
+    -webkit-transform: rotate(-12deg);
+    transform: rotate(-12deg);
+  }
+  36% {
+    -webkit-transform: rotate(12deg);
+    transform: rotate(12deg);
+  }
+  40%,
+  to {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+}
+@keyframes fa-shake {
+  0% {
+    -webkit-transform: rotate(-15deg);
+    transform: rotate(-15deg);
+  }
+  4% {
+    -webkit-transform: rotate(15deg);
+    transform: rotate(15deg);
+  }
+  8%,
+  24% {
+    -webkit-transform: rotate(-18deg);
+    transform: rotate(-18deg);
+  }
+  12%,
+  28% {
+    -webkit-transform: rotate(18deg);
+    transform: rotate(18deg);
+  }
+  16% {
+    -webkit-transform: rotate(-22deg);
+    transform: rotate(-22deg);
+  }
+  20% {
+    -webkit-transform: rotate(22deg);
+    transform: rotate(22deg);
+  }
+  32% {
+    -webkit-transform: rotate(-12deg);
+    transform: rotate(-12deg);
+  }
+  36% {
+    -webkit-transform: rotate(12deg);
+    transform: rotate(12deg);
+  }
+  40%,
+  to {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+}
+@-webkit-keyframes fa-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(1turn);
+    transform: rotate(1turn);
+  }
+}
+@keyframes fa-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(1turn);
+    transform: rotate(1turn);
+  }
+}
+.fa-rotate-90 {
+  -webkit-transform: rotate(90deg);
+  transform: rotate(90deg);
+}
+.fa-rotate-180 {
+  -webkit-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+.fa-rotate-270 {
+  -webkit-transform: rotate(270deg);
+  transform: rotate(270deg);
+}
+.fa-flip-horizontal {
+  -webkit-transform: scaleX(-1);
+  transform: scaleX(-1);
+}
+.fa-flip-vertical {
+  -webkit-transform: scaleY(-1);
+  transform: scaleY(-1);
+}
+.fa-flip-both,
+.fa-flip-horizontal.fa-flip-vertical {
+  -webkit-transform: scale(-1);
+  transform: scale(-1);
+}
+.fa-rotate-by {
+  -webkit-transform: rotate(var(--fa-rotate-angle, none));
+  transform: rotate(var(--fa-rotate-angle, none));
+}
+.fa-stack {
+  display: inline-block;
+  height: 2em;
+  line-height: 2em;
+  position: relative;
+  vertical-align: middle;
+  width: 2.5em;
+}
+.fa-stack-1x,
+.fa-stack-2x {
+  left: 0;
+  position: absolute;
+  text-align: center;
+  width: 100%;
+  z-index: var(--fa-stack-z-index, auto);
+}
+.fa-stack-1x {
+  line-height: inherit;
+}
+.fa-stack-2x {
+  font-size: 2em;
+}
+.fa-inverse {
+  color: var(--fa-inverse, #fff);
+}
+
+.fa-0:before {
+  content: "\30";
+}
+.fa-1:before {
+  content: "\31";
+}
+.fa-2:before {
+  content: "\32";
+}
+.fa-3:before {
+  content: "\33";
+}
+.fa-4:before {
+  content: "\34";
+}
+.fa-5:before {
+  content: "\35";
+}
+.fa-6:before {
+  content: "\36";
+}
+.fa-7:before {
+  content: "\37";
+}
+.fa-8:before {
+  content: "\38";
+}
+.fa-9:before {
+  content: "\39";
+}
+.fa-fill-drip:before {
+  content: "\f576";
+}
+.fa-arrows-to-circle:before {
+  content: "\e4bd";
+}
+.fa-chevron-circle-right:before,
+.fa-circle-chevron-right:before {
+  content: "\f138";
+}
+.fa-at:before {
+  content: "\40";
+}
+.fa-trash-alt:before,
+.fa-trash-can:before {
+  content: "\f2ed";
+}
+.fa-text-height:before {
+  content: "\f034";
+}
+.fa-user-times:before,
+.fa-user-xmark:before {
+  content: "\f235";
+}
+.fa-stethoscope:before {
+  content: "\f0f1";
+}
+.fa-comment-alt:before,
+.fa-message:before {
+  content: "\f27a";
+}
+.fa-info:before {
+  content: "\f129";
+}
+.fa-compress-alt:before,
+.fa-down-left-and-up-right-to-center:before {
+  content: "\f422";
+}
+.fa-explosion:before {
+  content: "\e4e9";
+}
+.fa-file-alt:before,
+.fa-file-lines:before,
+.fa-file-text:before {
+  content: "\f15c";
+}
+.fa-wave-square:before {
+  content: "\f83e";
+}
+.fa-ring:before {
+  content: "\f70b";
+}
+.fa-building-un:before {
+  content: "\e4d9";
+}
+.fa-dice-three:before {
+  content: "\f527";
+}
+.fa-calendar-alt:before,
+.fa-calendar-days:before {
+  content: "\f073";
+}
+.fa-anchor-circle-check:before {
+  content: "\e4aa";
+}
+.fa-building-circle-arrow-right:before {
+  content: "\e4d1";
+}
+.fa-volleyball-ball:before,
+.fa-volleyball:before {
+  content: "\f45f";
+}
+.fa-arrows-up-to-line:before {
+  content: "\e4c2";
+}
+.fa-sort-desc:before,
+.fa-sort-down:before {
+  content: "\f0dd";
+}
+.fa-circle-minus:before,
+.fa-minus-circle:before {
+  content: "\f056";
+}
+.fa-door-open:before {
+  content: "\f52b";
+}
+.fa-right-from-bracket:before,
+.fa-sign-out-alt:before {
+  content: "\f2f5";
+}
+.fa-atom:before {
+  content: "\f5d2";
+}
+.fa-soap:before {
+  content: "\e06e";
+}
+.fa-heart-music-camera-bolt:before,
+.fa-icons:before {
+  content: "\f86d";
+}
+.fa-microphone-alt-slash:before,
+.fa-microphone-lines-slash:before {
+  content: "\f539";
+}
+.fa-bridge-circle-check:before {
+  content: "\e4c9";
+}
+.fa-pump-medical:before {
+  content: "\e06a";
+}
+.fa-fingerprint:before {
+  content: "\f577";
+}
+.fa-hand-point-right:before {
+  content: "\f0a4";
+}
+.fa-magnifying-glass-location:before,
+.fa-search-location:before {
+  content: "\f689";
+}
+.fa-forward-step:before,
+.fa-step-forward:before {
+  content: "\f051";
+}
+.fa-face-smile-beam:before,
+.fa-smile-beam:before {
+  content: "\f5b8";
+}
+.fa-flag-checkered:before {
+  content: "\f11e";
+}
+.fa-football-ball:before,
+.fa-football:before {
+  content: "\f44e";
+}
+.fa-school-circle-exclamation:before {
+  content: "\e56c";
+}
+.fa-crop:before {
+  content: "\f125";
+}
+.fa-angle-double-down:before,
+.fa-angles-down:before {
+  content: "\f103";
+}
+.fa-users-rectangle:before {
+  content: "\e594";
+}
+.fa-people-roof:before {
+  content: "\e537";
+}
+.fa-people-line:before {
+  content: "\e534";
+}
+.fa-beer-mug-empty:before,
+.fa-beer:before {
+  content: "\f0fc";
+}
+.fa-diagram-predecessor:before {
+  content: "\e477";
+}
+.fa-arrow-up-long:before,
+.fa-long-arrow-up:before {
+  content: "\f176";
+}
+.fa-burn:before,
+.fa-fire-flame-simple:before {
+  content: "\f46a";
+}
+.fa-male:before,
+.fa-person:before {
+  content: "\f183";
+}
+.fa-laptop:before {
+  content: "\f109";
+}
+.fa-file-csv:before {
+  content: "\f6dd";
+}
+.fa-menorah:before {
+  content: "\f676";
+}
+.fa-truck-plane:before {
+  content: "\e58f";
+}
+.fa-record-vinyl:before {
+  content: "\f8d9";
+}
+.fa-face-grin-stars:before,
+.fa-grin-stars:before {
+  content: "\f587";
+}
+.fa-bong:before {
+  content: "\f55c";
+}
+.fa-pastafarianism:before,
+.fa-spaghetti-monster-flying:before {
+  content: "\f67b";
+}
+.fa-arrow-down-up-across-line:before {
+  content: "\e4af";
+}
+.fa-spoon:before,
+.fa-utensil-spoon:before {
+  content: "\f2e5";
+}
+.fa-jar-wheat:before {
+  content: "\e517";
+}
+.fa-envelopes-bulk:before,
+.fa-mail-bulk:before {
+  content: "\f674";
+}
+.fa-file-circle-exclamation:before {
+  content: "\e4eb";
+}
+.fa-circle-h:before,
+.fa-hospital-symbol:before {
+  content: "\f47e";
+}
+.fa-pager:before {
+  content: "\f815";
+}
+.fa-address-book:before,
+.fa-contact-book:before {
+  content: "\f2b9";
+}
+.fa-strikethrough:before {
+  content: "\f0cc";
+}
+.fa-k:before {
+  content: "\4b";
+}
+.fa-landmark-flag:before {
+  content: "\e51c";
+}
+.fa-pencil-alt:before,
+.fa-pencil:before {
+  content: "\f303";
+}
+.fa-backward:before {
+  content: "\f04a";
+}
+.fa-caret-right:before {
+  content: "\f0da";
+}
+.fa-comments:before {
+  content: "\f086";
+}
+.fa-file-clipboard:before,
+.fa-paste:before {
+  content: "\f0ea";
+}
+.fa-code-pull-request:before {
+  content: "\e13c";
+}
+.fa-clipboard-list:before {
+  content: "\f46d";
+}
+.fa-truck-loading:before,
+.fa-truck-ramp-box:before {
+  content: "\f4de";
+}
+.fa-user-check:before {
+  content: "\f4fc";
+}
+.fa-vial-virus:before {
+  content: "\e597";
+}
+.fa-sheet-plastic:before {
+  content: "\e571";
+}
+.fa-blog:before {
+  content: "\f781";
+}
+.fa-user-ninja:before {
+  content: "\f504";
+}
+.fa-person-arrow-up-from-line:before {
+  content: "\e539";
+}
+.fa-scroll-torah:before,
+.fa-torah:before {
+  content: "\f6a0";
+}
+.fa-broom-ball:before,
+.fa-quidditch-broom-ball:before,
+.fa-quidditch:before {
+  content: "\f458";
+}
+.fa-toggle-off:before {
+  content: "\f204";
+}
+.fa-archive:before,
+.fa-box-archive:before {
+  content: "\f187";
+}
+.fa-person-drowning:before {
+  content: "\e545";
+}
+.fa-arrow-down-9-1:before,
+.fa-sort-numeric-desc:before,
+.fa-sort-numeric-down-alt:before {
+  content: "\f886";
+}
+.fa-face-grin-tongue-squint:before,
+.fa-grin-tongue-squint:before {
+  content: "\f58a";
+}
+.fa-spray-can:before {
+  content: "\f5bd";
+}
+.fa-truck-monster:before {
+  content: "\f63b";
+}
+.fa-w:before {
+  content: "\57";
+}
+.fa-earth-africa:before,
+.fa-globe-africa:before {
+  content: "\f57c";
+}
+.fa-rainbow:before {
+  content: "\f75b";
+}
+.fa-circle-notch:before {
+  content: "\f1ce";
+}
+.fa-tablet-alt:before,
+.fa-tablet-screen-button:before {
+  content: "\f3fa";
+}
+.fa-paw:before {
+  content: "\f1b0";
+}
+.fa-cloud:before {
+  content: "\f0c2";
+}
+.fa-trowel-bricks:before {
+  content: "\e58a";
+}
+.fa-face-flushed:before,
+.fa-flushed:before {
+  content: "\f579";
+}
+.fa-hospital-user:before {
+  content: "\f80d";
+}
+.fa-tent-arrow-left-right:before {
+  content: "\e57f";
+}
+.fa-gavel:before,
+.fa-legal:before {
+  content: "\f0e3";
+}
+.fa-binoculars:before {
+  content: "\f1e5";
+}
+.fa-microphone-slash:before {
+  content: "\f131";
+}
+.fa-box-tissue:before {
+  content: "\e05b";
+}
+.fa-motorcycle:before {
+  content: "\f21c";
+}
+.fa-bell-concierge:before,
+.fa-concierge-bell:before {
+  content: "\f562";
+}
+.fa-pen-ruler:before,
+.fa-pencil-ruler:before {
+  content: "\f5ae";
+}
+.fa-people-arrows-left-right:before,
+.fa-people-arrows:before {
+  content: "\e068";
+}
+.fa-mars-and-venus-burst:before {
+  content: "\e523";
+}
+.fa-caret-square-right:before,
+.fa-square-caret-right:before {
+  content: "\f152";
+}
+.fa-cut:before,
+.fa-scissors:before {
+  content: "\f0c4";
+}
+.fa-sun-plant-wilt:before {
+  content: "\e57a";
+}
+.fa-toilets-portable:before {
+  content: "\e584";
+}
+.fa-hockey-puck:before {
+  content: "\f453";
+}
+.fa-table:before {
+  content: "\f0ce";
+}
+.fa-magnifying-glass-arrow-right:before {
+  content: "\e521";
+}
+.fa-digital-tachograph:before,
+.fa-tachograph-digital:before {
+  content: "\f566";
+}
+.fa-users-slash:before {
+  content: "\e073";
+}
+.fa-clover:before {
+  content: "\e139";
+}
+.fa-mail-reply:before,
+.fa-reply:before {
+  content: "\f3e5";
+}
+.fa-star-and-crescent:before {
+  content: "\f699";
+}
+.fa-house-fire:before {
+  content: "\e50c";
+}
+.fa-minus-square:before,
+.fa-square-minus:before {
+  content: "\f146";
+}
+.fa-helicopter:before {
+  content: "\f533";
+}
+.fa-compass:before {
+  content: "\f14e";
+}
+.fa-caret-square-down:before,
+.fa-square-caret-down:before {
+  content: "\f150";
+}
+.fa-file-circle-question:before {
+  content: "\e4ef";
+}
+.fa-laptop-code:before {
+  content: "\f5fc";
+}
+.fa-swatchbook:before {
+  content: "\f5c3";
+}
+.fa-prescription-bottle:before {
+  content: "\f485";
+}
+.fa-bars:before,
+.fa-navicon:before {
+  content: "\f0c9";
+}
+.fa-people-group:before {
+  content: "\e533";
+}
+.fa-hourglass-3:before,
+.fa-hourglass-end:before {
+  content: "\f253";
+}
+.fa-heart-broken:before,
+.fa-heart-crack:before {
+  content: "\f7a9";
+}
+.fa-external-link-square-alt:before,
+.fa-square-up-right:before {
+  content: "\f360";
+}
+.fa-face-kiss-beam:before,
+.fa-kiss-beam:before {
+  content: "\f597";
+}
+.fa-film:before {
+  content: "\f008";
+}
+.fa-ruler-horizontal:before {
+  content: "\f547";
+}
+.fa-people-robbery:before {
+  content: "\e536";
+}
+.fa-lightbulb:before {
+  content: "\f0eb";
+}
+.fa-caret-left:before {
+  content: "\f0d9";
+}
+.fa-circle-exclamation:before,
+.fa-exclamation-circle:before {
+  content: "\f06a";
+}
+.fa-school-circle-xmark:before {
+  content: "\e56d";
+}
+.fa-arrow-right-from-bracket:before,
+.fa-sign-out:before {
+  content: "\f08b";
+}
+.fa-chevron-circle-down:before,
+.fa-circle-chevron-down:before {
+  content: "\f13a";
+}
+.fa-unlock-alt:before,
+.fa-unlock-keyhole:before {
+  content: "\f13e";
+}
+.fa-cloud-showers-heavy:before {
+  content: "\f740";
+}
+.fa-headphones-alt:before,
+.fa-headphones-simple:before {
+  content: "\f58f";
+}
+.fa-sitemap:before {
+  content: "\f0e8";
+}
+.fa-circle-dollar-to-slot:before,
+.fa-donate:before {
+  content: "\f4b9";
+}
+.fa-memory:before {
+  content: "\f538";
+}
+.fa-road-spikes:before {
+  content: "\e568";
+}
+.fa-fire-burner:before {
+  content: "\e4f1";
+}
+.fa-flag:before {
+  content: "\f024";
+}
+.fa-hanukiah:before {
+  content: "\f6e6";
+}
+.fa-feather:before {
+  content: "\f52d";
+}
+.fa-volume-down:before,
+.fa-volume-low:before {
+  content: "\f027";
+}
+.fa-comment-slash:before {
+  content: "\f4b3";
+}
+.fa-cloud-sun-rain:before {
+  content: "\f743";
+}
+.fa-compress:before {
+  content: "\f066";
+}
+.fa-wheat-alt:before,
+.fa-wheat-awn:before {
+  content: "\e2cd";
+}
+.fa-ankh:before {
+  content: "\f644";
+}
+.fa-hands-holding-child:before {
+  content: "\e4fa";
+}
+.fa-asterisk:before {
+  content: "\2a";
+}
+.fa-check-square:before,
+.fa-square-check:before {
+  content: "\f14a";
+}
+.fa-peseta-sign:before {
+  content: "\e221";
+}
+.fa-header:before,
+.fa-heading:before {
+  content: "\f1dc";
+}
+.fa-ghost:before {
+  content: "\f6e2";
+}
+.fa-list-squares:before,
+.fa-list:before {
+  content: "\f03a";
+}
+.fa-phone-square-alt:before,
+.fa-square-phone-flip:before {
+  content: "\f87b";
+}
+.fa-cart-plus:before {
+  content: "\f217";
+}
+.fa-gamepad:before {
+  content: "\f11b";
+}
+.fa-circle-dot:before,
+.fa-dot-circle:before {
+  content: "\f192";
+}
+.fa-dizzy:before,
+.fa-face-dizzy:before {
+  content: "\f567";
+}
+.fa-egg:before {
+  content: "\f7fb";
+}
+.fa-house-medical-circle-xmark:before {
+  content: "\e513";
+}
+.fa-campground:before {
+  content: "\f6bb";
+}
+.fa-folder-plus:before {
+  content: "\f65e";
+}
+.fa-futbol-ball:before,
+.fa-futbol:before,
+.fa-soccer-ball:before {
+  content: "\f1e3";
+}
+.fa-paint-brush:before,
+.fa-paintbrush:before {
+  content: "\f1fc";
+}
+.fa-lock:before {
+  content: "\f023";
+}
+.fa-gas-pump:before {
+  content: "\f52f";
+}
+.fa-hot-tub-person:before,
+.fa-hot-tub:before {
+  content: "\f593";
+}
+.fa-map-location:before,
+.fa-map-marked:before {
+  content: "\f59f";
+}
+.fa-house-flood-water:before {
+  content: "\e50e";
+}
+.fa-tree:before {
+  content: "\f1bb";
+}
+.fa-bridge-lock:before {
+  content: "\e4cc";
+}
+.fa-sack-dollar:before {
+  content: "\f81d";
+}
+.fa-edit:before,
+.fa-pen-to-square:before {
+  content: "\f044";
+}
+.fa-car-side:before {
+  content: "\f5e4";
+}
+.fa-share-alt:before,
+.fa-share-nodes:before {
+  content: "\f1e0";
+}
+.fa-heart-circle-minus:before {
+  content: "\e4ff";
+}
+.fa-hourglass-2:before,
+.fa-hourglass-half:before {
+  content: "\f252";
+}
+.fa-microscope:before {
+  content: "\f610";
+}
+.fa-sink:before {
+  content: "\e06d";
+}
+.fa-bag-shopping:before,
+.fa-shopping-bag:before {
+  content: "\f290";
+}
+.fa-arrow-down-z-a:before,
+.fa-sort-alpha-desc:before,
+.fa-sort-alpha-down-alt:before {
+  content: "\f881";
+}
+.fa-mitten:before {
+  content: "\f7b5";
+}
+.fa-person-rays:before {
+  content: "\e54d";
+}
+.fa-users:before {
+  content: "\f0c0";
+}
+.fa-eye-slash:before {
+  content: "\f070";
+}
+.fa-flask-vial:before {
+  content: "\e4f3";
+}
+.fa-hand-paper:before,
+.fa-hand:before {
+  content: "\f256";
+}
+.fa-om:before {
+  content: "\f679";
+}
+.fa-worm:before {
+  content: "\e599";
+}
+.fa-house-circle-xmark:before {
+  content: "\e50b";
+}
+.fa-plug:before {
+  content: "\f1e6";
+}
+.fa-chevron-up:before {
+  content: "\f077";
+}
+.fa-hand-spock:before {
+  content: "\f259";
+}
+.fa-stopwatch:before {
+  content: "\f2f2";
+}
+.fa-face-kiss:before,
+.fa-kiss:before {
+  content: "\f596";
+}
+.fa-bridge-circle-xmark:before {
+  content: "\e4cb";
+}
+.fa-face-grin-tongue:before,
+.fa-grin-tongue:before {
+  content: "\f589";
+}
+.fa-chess-bishop:before {
+  content: "\f43a";
+}
+.fa-face-grin-wink:before,
+.fa-grin-wink:before {
+  content: "\f58c";
+}
+.fa-deaf:before,
+.fa-deafness:before,
+.fa-ear-deaf:before,
+.fa-hard-of-hearing:before {
+  content: "\f2a4";
+}
+.fa-road-circle-check:before {
+  content: "\e564";
+}
+.fa-dice-five:before {
+  content: "\f523";
+}
+.fa-rss-square:before,
+.fa-square-rss:before {
+  content: "\f143";
+}
+.fa-land-mine-on:before {
+  content: "\e51b";
+}
+.fa-i-cursor:before {
+  content: "\f246";
+}
+.fa-stamp:before {
+  content: "\f5bf";
+}
+.fa-stairs:before {
+  content: "\e289";
+}
+.fa-i:before {
+  content: "\49";
+}
+.fa-hryvnia-sign:before,
+.fa-hryvnia:before {
+  content: "\f6f2";
+}
+.fa-pills:before {
+  content: "\f484";
+}
+.fa-face-grin-wide:before,
+.fa-grin-alt:before {
+  content: "\f581";
+}
+.fa-tooth:before {
+  content: "\f5c9";
+}
+.fa-v:before {
+  content: "\56";
+}
+.fa-bangladeshi-taka-sign:before {
+  content: "\e2e6";
+}
+.fa-bicycle:before {
+  content: "\f206";
+}
+.fa-rod-asclepius:before,
+.fa-rod-snake:before,
+.fa-staff-aesculapius:before,
+.fa-staff-snake:before {
+  content: "\e579";
+}
+.fa-head-side-cough-slash:before {
+  content: "\e062";
+}
+.fa-ambulance:before,
+.fa-truck-medical:before {
+  content: "\f0f9";
+}
+.fa-wheat-awn-circle-exclamation:before {
+  content: "\e598";
+}
+.fa-snowman:before {
+  content: "\f7d0";
+}
+.fa-mortar-pestle:before {
+  content: "\f5a7";
+}
+.fa-road-barrier:before {
+  content: "\e562";
+}
+.fa-school:before {
+  content: "\f549";
+}
+.fa-igloo:before {
+  content: "\f7ae";
+}
+.fa-joint:before {
+  content: "\f595";
+}
+.fa-angle-right:before {
+  content: "\f105";
+}
+.fa-horse:before {
+  content: "\f6f0";
+}
+.fa-q:before {
+  content: "\51";
+}
+.fa-g:before {
+  content: "\47";
+}
+.fa-notes-medical:before {
+  content: "\f481";
+}
+.fa-temperature-2:before,
+.fa-temperature-half:before,
+.fa-thermometer-2:before,
+.fa-thermometer-half:before {
+  content: "\f2c9";
+}
+.fa-dong-sign:before {
+  content: "\e169";
+}
+.fa-capsules:before {
+  content: "\f46b";
+}
+.fa-poo-bolt:before,
+.fa-poo-storm:before {
+  content: "\f75a";
+}
+.fa-face-frown-open:before,
+.fa-frown-open:before {
+  content: "\f57a";
+}
+.fa-hand-point-up:before {
+  content: "\f0a6";
+}
+.fa-money-bill:before {
+  content: "\f0d6";
+}
+.fa-bookmark:before {
+  content: "\f02e";
+}
+.fa-align-justify:before {
+  content: "\f039";
+}
+.fa-umbrella-beach:before {
+  content: "\f5ca";
+}
+.fa-helmet-un:before {
+  content: "\e503";
+}
+.fa-bullseye:before {
+  content: "\f140";
+}
+.fa-bacon:before {
+  content: "\f7e5";
+}
+.fa-hand-point-down:before {
+  content: "\f0a7";
+}
+.fa-arrow-up-from-bracket:before {
+  content: "\e09a";
+}
+.fa-folder-blank:before,
+.fa-folder:before {
+  content: "\f07b";
+}
+.fa-file-medical-alt:before,
+.fa-file-waveform:before {
+  content: "\f478";
+}
+.fa-radiation:before {
+  content: "\f7b9";
+}
+.fa-chart-simple:before {
+  content: "\e473";
+}
+.fa-mars-stroke:before {
+  content: "\f229";
+}
+.fa-vial:before {
+  content: "\f492";
+}
+.fa-dashboard:before,
+.fa-gauge-med:before,
+.fa-gauge:before,
+.fa-tachometer-alt-average:before {
+  content: "\f624";
+}
+.fa-magic-wand-sparkles:before,
+.fa-wand-magic-sparkles:before {
+  content: "\e2ca";
+}
+.fa-e:before {
+  content: "\45";
+}
+.fa-pen-alt:before,
+.fa-pen-clip:before {
+  content: "\f305";
+}
+.fa-bridge-circle-exclamation:before {
+  content: "\e4ca";
+}
+.fa-user:before {
+  content: "\f007";
+}
+.fa-school-circle-check:before {
+  content: "\e56b";
+}
+.fa-dumpster:before {
+  content: "\f793";
+}
+.fa-shuttle-van:before,
+.fa-van-shuttle:before {
+  content: "\f5b6";
+}
+.fa-building-user:before {
+  content: "\e4da";
+}
+.fa-caret-square-left:before,
+.fa-square-caret-left:before {
+  content: "\f191";
+}
+.fa-highlighter:before {
+  content: "\f591";
+}
+.fa-key:before {
+  content: "\f084";
+}
+.fa-bullhorn:before {
+  content: "\f0a1";
+}
+.fa-globe:before {
+  content: "\f0ac";
+}
+.fa-synagogue:before {
+  content: "\f69b";
+}
+.fa-person-half-dress:before {
+  content: "\e548";
+}
+.fa-road-bridge:before {
+  content: "\e563";
+}
+.fa-location-arrow:before {
+  content: "\f124";
+}
+.fa-c:before {
+  content: "\43";
+}
+.fa-tablet-button:before {
+  content: "\f10a";
+}
+.fa-building-lock:before {
+  content: "\e4d6";
+}
+.fa-pizza-slice:before {
+  content: "\f818";
+}
+.fa-money-bill-wave:before {
+  content: "\f53a";
+}
+.fa-area-chart:before,
+.fa-chart-area:before {
+  content: "\f1fe";
+}
+.fa-house-flag:before {
+  content: "\e50d";
+}
+.fa-person-circle-minus:before {
+  content: "\e540";
+}
+.fa-ban:before,
+.fa-cancel:before {
+  content: "\f05e";
+}
+.fa-camera-rotate:before {
+  content: "\e0d8";
+}
+.fa-air-freshener:before,
+.fa-spray-can-sparkles:before {
+  content: "\f5d0";
+}
+.fa-star:before {
+  content: "\f005";
+}
+.fa-repeat:before {
+  content: "\f363";
+}
+.fa-cross:before {
+  content: "\f654";
+}
+.fa-box:before {
+  content: "\f466";
+}
+.fa-venus-mars:before {
+  content: "\f228";
+}
+.fa-arrow-pointer:before,
+.fa-mouse-pointer:before {
+  content: "\f245";
+}
+.fa-expand-arrows-alt:before,
+.fa-maximize:before {
+  content: "\f31e";
+}
+.fa-charging-station:before {
+  content: "\f5e7";
+}
+.fa-shapes:before,
+.fa-triangle-circle-square:before {
+  content: "\f61f";
+}
+.fa-random:before,
+.fa-shuffle:before {
+  content: "\f074";
+}
+.fa-person-running:before,
+.fa-running:before {
+  content: "\f70c";
+}
+.fa-mobile-retro:before {
+  content: "\e527";
+}
+.fa-grip-lines-vertical:before {
+  content: "\f7a5";
+}
+.fa-spider:before {
+  content: "\f717";
+}
+.fa-hands-bound:before {
+  content: "\e4f9";
+}
+.fa-file-invoice-dollar:before {
+  content: "\f571";
+}
+.fa-plane-circle-exclamation:before {
+  content: "\e556";
+}
+.fa-x-ray:before {
+  content: "\f497";
+}
+.fa-spell-check:before {
+  content: "\f891";
+}
+.fa-slash:before {
+  content: "\f715";
+}
+.fa-computer-mouse:before,
+.fa-mouse:before {
+  content: "\f8cc";
+}
+.fa-arrow-right-to-bracket:before,
+.fa-sign-in:before {
+  content: "\f090";
+}
+.fa-shop-slash:before,
+.fa-store-alt-slash:before {
+  content: "\e070";
+}
+.fa-server:before {
+  content: "\f233";
+}
+.fa-virus-covid-slash:before {
+  content: "\e4a9";
+}
+.fa-shop-lock:before {
+  content: "\e4a5";
+}
+.fa-hourglass-1:before,
+.fa-hourglass-start:before {
+  content: "\f251";
+}
+.fa-blender-phone:before {
+  content: "\f6b6";
+}
+.fa-building-wheat:before {
+  content: "\e4db";
+}
+.fa-person-breastfeeding:before {
+  content: "\e53a";
+}
+.fa-right-to-bracket:before,
+.fa-sign-in-alt:before {
+  content: "\f2f6";
+}
+.fa-venus:before {
+  content: "\f221";
+}
+.fa-passport:before {
+  content: "\f5ab";
+}
+.fa-heart-pulse:before,
+.fa-heartbeat:before {
+  content: "\f21e";
+}
+.fa-people-carry-box:before,
+.fa-people-carry:before {
+  content: "\f4ce";
+}
+.fa-temperature-high:before {
+  content: "\f769";
+}
+.fa-microchip:before {
+  content: "\f2db";
+}
+.fa-crown:before {
+  content: "\f521";
+}
+.fa-weight-hanging:before {
+  content: "\f5cd";
+}
+.fa-xmarks-lines:before {
+  content: "\e59a";
+}
+.fa-file-prescription:before {
+  content: "\f572";
+}
+.fa-weight-scale:before,
+.fa-weight:before {
+  content: "\f496";
+}
+.fa-user-friends:before,
+.fa-user-group:before {
+  content: "\f500";
+}
+.fa-arrow-up-a-z:before,
+.fa-sort-alpha-up:before {
+  content: "\f15e";
+}
+.fa-chess-knight:before {
+  content: "\f441";
+}
+.fa-face-laugh-squint:before,
+.fa-laugh-squint:before {
+  content: "\f59b";
+}
+.fa-wheelchair:before {
+  content: "\f193";
+}
+.fa-arrow-circle-up:before,
+.fa-circle-arrow-up:before {
+  content: "\f0aa";
+}
+.fa-toggle-on:before {
+  content: "\f205";
+}
+.fa-person-walking:before,
+.fa-walking:before {
+  content: "\f554";
+}
+.fa-l:before {
+  content: "\4c";
+}
+.fa-fire:before {
+  content: "\f06d";
+}
+.fa-bed-pulse:before,
+.fa-procedures:before {
+  content: "\f487";
+}
+.fa-shuttle-space:before,
+.fa-space-shuttle:before {
+  content: "\f197";
+}
+.fa-face-laugh:before,
+.fa-laugh:before {
+  content: "\f599";
+}
+.fa-folder-open:before {
+  content: "\f07c";
+}
+.fa-heart-circle-plus:before {
+  content: "\e500";
+}
+.fa-code-fork:before {
+  content: "\e13b";
+}
+.fa-city:before {
+  content: "\f64f";
+}
+.fa-microphone-alt:before,
+.fa-microphone-lines:before {
+  content: "\f3c9";
+}
+.fa-pepper-hot:before {
+  content: "\f816";
+}
+.fa-unlock:before {
+  content: "\f09c";
+}
+.fa-colon-sign:before {
+  content: "\e140";
+}
+.fa-headset:before {
+  content: "\f590";
+}
+.fa-store-slash:before {
+  content: "\e071";
+}
+.fa-road-circle-xmark:before {
+  content: "\e566";
+}
+.fa-user-minus:before {
+  content: "\f503";
+}
+.fa-mars-stroke-up:before,
+.fa-mars-stroke-v:before {
+  content: "\f22a";
+}
+.fa-champagne-glasses:before,
+.fa-glass-cheers:before {
+  content: "\f79f";
+}
+.fa-clipboard:before {
+  content: "\f328";
+}
+.fa-house-circle-exclamation:before {
+  content: "\e50a";
+}
+.fa-file-arrow-up:before,
+.fa-file-upload:before {
+  content: "\f574";
+}
+.fa-wifi-3:before,
+.fa-wifi-strong:before,
+.fa-wifi:before {
+  content: "\f1eb";
+}
+.fa-bath:before,
+.fa-bathtub:before {
+  content: "\f2cd";
+}
+.fa-underline:before {
+  content: "\f0cd";
+}
+.fa-user-edit:before,
+.fa-user-pen:before {
+  content: "\f4ff";
+}
+.fa-signature:before {
+  content: "\f5b7";
+}
+.fa-stroopwafel:before {
+  content: "\f551";
+}
+.fa-bold:before {
+  content: "\f032";
+}
+.fa-anchor-lock:before {
+  content: "\e4ad";
+}
+.fa-building-ngo:before {
+  content: "\e4d7";
+}
+.fa-manat-sign:before {
+  content: "\e1d5";
+}
+.fa-not-equal:before {
+  content: "\f53e";
+}
+.fa-border-style:before,
+.fa-border-top-left:before {
+  content: "\f853";
+}
+.fa-map-location-dot:before,
+.fa-map-marked-alt:before {
+  content: "\f5a0";
+}
+.fa-jedi:before {
+  content: "\f669";
+}
+.fa-poll:before,
+.fa-square-poll-vertical:before {
+  content: "\f681";
+}
+.fa-mug-hot:before {
+  content: "\f7b6";
+}
+.fa-battery-car:before,
+.fa-car-battery:before {
+  content: "\f5df";
+}
+.fa-gift:before {
+  content: "\f06b";
+}
+.fa-dice-two:before {
+  content: "\f528";
+}
+.fa-chess-queen:before {
+  content: "\f445";
+}
+.fa-glasses:before {
+  content: "\f530";
+}
+.fa-chess-board:before {
+  content: "\f43c";
+}
+.fa-building-circle-check:before {
+  content: "\e4d2";
+}
+.fa-person-chalkboard:before {
+  content: "\e53d";
+}
+.fa-mars-stroke-h:before,
+.fa-mars-stroke-right:before {
+  content: "\f22b";
+}
+.fa-hand-back-fist:before,
+.fa-hand-rock:before {
+  content: "\f255";
+}
+.fa-caret-square-up:before,
+.fa-square-caret-up:before {
+  content: "\f151";
+}
+.fa-cloud-showers-water:before {
+  content: "\e4e4";
+}
+.fa-bar-chart:before,
+.fa-chart-bar:before {
+  content: "\f080";
+}
+.fa-hands-bubbles:before,
+.fa-hands-wash:before {
+  content: "\e05e";
+}
+.fa-less-than-equal:before {
+  content: "\f537";
+}
+.fa-train:before {
+  content: "\f238";
+}
+.fa-eye-low-vision:before,
+.fa-low-vision:before {
+  content: "\f2a8";
+}
+.fa-crow:before {
+  content: "\f520";
+}
+.fa-sailboat:before {
+  content: "\e445";
+}
+.fa-window-restore:before {
+  content: "\f2d2";
+}
+.fa-plus-square:before,
+.fa-square-plus:before {
+  content: "\f0fe";
+}
+.fa-torii-gate:before {
+  content: "\f6a1";
+}
+.fa-frog:before {
+  content: "\f52e";
+}
+.fa-bucket:before {
+  content: "\e4cf";
+}
+.fa-image:before {
+  content: "\f03e";
+}
+.fa-microphone:before {
+  content: "\f130";
+}
+.fa-cow:before {
+  content: "\f6c8";
+}
+.fa-caret-up:before {
+  content: "\f0d8";
+}
+.fa-screwdriver:before {
+  content: "\f54a";
+}
+.fa-folder-closed:before {
+  content: "\e185";
+}
+.fa-house-tsunami:before {
+  content: "\e515";
+}
+.fa-square-nfi:before {
+  content: "\e576";
+}
+.fa-arrow-up-from-ground-water:before {
+  content: "\e4b5";
+}
+.fa-glass-martini-alt:before,
+.fa-martini-glass:before {
+  content: "\f57b";
+}
+.fa-rotate-back:before,
+.fa-rotate-backward:before,
+.fa-rotate-left:before,
+.fa-undo-alt:before {
+  content: "\f2ea";
+}
+.fa-columns:before,
+.fa-table-columns:before {
+  content: "\f0db";
+}
+.fa-lemon:before {
+  content: "\f094";
+}
+.fa-head-side-mask:before {
+  content: "\e063";
+}
+.fa-handshake:before {
+  content: "\f2b5";
+}
+.fa-gem:before {
+  content: "\f3a5";
+}
+.fa-dolly-box:before,
+.fa-dolly:before {
+  content: "\f472";
+}
+.fa-smoking:before {
+  content: "\f48d";
+}
+.fa-compress-arrows-alt:before,
+.fa-minimize:before {
+  content: "\f78c";
+}
+.fa-monument:before {
+  content: "\f5a6";
+}
+.fa-snowplow:before {
+  content: "\f7d2";
+}
+.fa-angle-double-right:before,
+.fa-angles-right:before {
+  content: "\f101";
+}
+.fa-cannabis:before {
+  content: "\f55f";
+}
+.fa-circle-play:before,
+.fa-play-circle:before {
+  content: "\f144";
+}
+.fa-tablets:before {
+  content: "\f490";
+}
+.fa-ethernet:before {
+  content: "\f796";
+}
+.fa-eur:before,
+.fa-euro-sign:before,
+.fa-euro:before {
+  content: "\f153";
+}
+.fa-chair:before {
+  content: "\f6c0";
+}
+.fa-check-circle:before,
+.fa-circle-check:before {
+  content: "\f058";
+}
+.fa-circle-stop:before,
+.fa-stop-circle:before {
+  content: "\f28d";
+}
+.fa-compass-drafting:before,
+.fa-drafting-compass:before {
+  content: "\f568";
+}
+.fa-plate-wheat:before {
+  content: "\e55a";
+}
+.fa-icicles:before {
+  content: "\f7ad";
+}
+.fa-person-shelter:before {
+  content: "\e54f";
+}
+.fa-neuter:before {
+  content: "\f22c";
+}
+.fa-id-badge:before {
+  content: "\f2c1";
+}
+.fa-marker:before {
+  content: "\f5a1";
+}
+.fa-face-laugh-beam:before,
+.fa-laugh-beam:before {
+  content: "\f59a";
+}
+.fa-helicopter-symbol:before {
+  content: "\e502";
+}
+.fa-universal-access:before {
+  content: "\f29a";
+}
+.fa-chevron-circle-up:before,
+.fa-circle-chevron-up:before {
+  content: "\f139";
+}
+.fa-lari-sign:before {
+  content: "\e1c8";
+}
+.fa-volcano:before {
+  content: "\f770";
+}
+.fa-person-walking-dashed-line-arrow-right:before {
+  content: "\e553";
+}
+.fa-gbp:before,
+.fa-pound-sign:before,
+.fa-sterling-sign:before {
+  content: "\f154";
+}
+.fa-viruses:before {
+  content: "\e076";
+}
+.fa-square-person-confined:before {
+  content: "\e577";
+}
+.fa-user-tie:before {
+  content: "\f508";
+}
+.fa-arrow-down-long:before,
+.fa-long-arrow-down:before {
+  content: "\f175";
+}
+.fa-tent-arrow-down-to-line:before {
+  content: "\e57e";
+}
+.fa-certificate:before {
+  content: "\f0a3";
+}
+.fa-mail-reply-all:before,
+.fa-reply-all:before {
+  content: "\f122";
+}
+.fa-suitcase:before {
+  content: "\f0f2";
+}
+.fa-person-skating:before,
+.fa-skating:before {
+  content: "\f7c5";
+}
+.fa-filter-circle-dollar:before,
+.fa-funnel-dollar:before {
+  content: "\f662";
+}
+.fa-camera-retro:before {
+  content: "\f083";
+}
+.fa-arrow-circle-down:before,
+.fa-circle-arrow-down:before {
+  content: "\f0ab";
+}
+.fa-arrow-right-to-file:before,
+.fa-file-import:before {
+  content: "\f56f";
+}
+.fa-external-link-square:before,
+.fa-square-arrow-up-right:before {
+  content: "\f14c";
+}
+.fa-box-open:before {
+  content: "\f49e";
+}
+.fa-scroll:before {
+  content: "\f70e";
+}
+.fa-spa:before {
+  content: "\f5bb";
+}
+.fa-location-pin-lock:before {
+  content: "\e51f";
+}
+.fa-pause:before {
+  content: "\f04c";
+}
+.fa-hill-avalanche:before {
+  content: "\e507";
+}
+.fa-temperature-0:before,
+.fa-temperature-empty:before,
+.fa-thermometer-0:before,
+.fa-thermometer-empty:before {
+  content: "\f2cb";
+}
+.fa-bomb:before {
+  content: "\f1e2";
+}
+.fa-registered:before {
+  content: "\f25d";
+}
+.fa-address-card:before,
+.fa-contact-card:before,
+.fa-vcard:before {
+  content: "\f2bb";
+}
+.fa-balance-scale-right:before,
+.fa-scale-unbalanced-flip:before {
+  content: "\f516";
+}
+.fa-subscript:before {
+  content: "\f12c";
+}
+.fa-diamond-turn-right:before,
+.fa-directions:before {
+  content: "\f5eb";
+}
+.fa-burst:before {
+  content: "\e4dc";
+}
+.fa-house-laptop:before,
+.fa-laptop-house:before {
+  content: "\e066";
+}
+.fa-face-tired:before,
+.fa-tired:before {
+  content: "\f5c8";
+}
+.fa-money-bills:before {
+  content: "\e1f3";
+}
+.fa-smog:before {
+  content: "\f75f";
+}
+.fa-crutch:before {
+  content: "\f7f7";
+}
+.fa-cloud-arrow-up:before,
+.fa-cloud-upload-alt:before,
+.fa-cloud-upload:before {
+  content: "\f0ee";
+}
+.fa-palette:before {
+  content: "\f53f";
+}
+.fa-arrows-turn-right:before {
+  content: "\e4c0";
+}
+.fa-vest:before {
+  content: "\e085";
+}
+.fa-ferry:before {
+  content: "\e4ea";
+}
+.fa-arrows-down-to-people:before {
+  content: "\e4b9";
+}
+.fa-seedling:before,
+.fa-sprout:before {
+  content: "\f4d8";
+}
+.fa-arrows-alt-h:before,
+.fa-left-right:before {
+  content: "\f337";
+}
+.fa-boxes-packing:before {
+  content: "\e4c7";
+}
+.fa-arrow-circle-left:before,
+.fa-circle-arrow-left:before {
+  content: "\f0a8";
+}
+.fa-group-arrows-rotate:before {
+  content: "\e4f6";
+}
+.fa-bowl-food:before {
+  content: "\e4c6";
+}
+.fa-candy-cane:before {
+  content: "\f786";
+}
+.fa-arrow-down-wide-short:before,
+.fa-sort-amount-asc:before,
+.fa-sort-amount-down:before {
+  content: "\f160";
+}
+.fa-cloud-bolt:before,
+.fa-thunderstorm:before {
+  content: "\f76c";
+}
+.fa-remove-format:before,
+.fa-text-slash:before {
+  content: "\f87d";
+}
+.fa-face-smile-wink:before,
+.fa-smile-wink:before {
+  content: "\f4da";
+}
+.fa-file-word:before {
+  content: "\f1c2";
+}
+.fa-file-powerpoint:before {
+  content: "\f1c4";
+}
+.fa-arrows-h:before,
+.fa-arrows-left-right:before {
+  content: "\f07e";
+}
+.fa-house-lock:before {
+  content: "\e510";
+}
+.fa-cloud-arrow-down:before,
+.fa-cloud-download-alt:before,
+.fa-cloud-download:before {
+  content: "\f0ed";
+}
+.fa-children:before {
+  content: "\e4e1";
+}
+.fa-blackboard:before,
+.fa-chalkboard:before {
+  content: "\f51b";
+}
+.fa-user-alt-slash:before,
+.fa-user-large-slash:before {
+  content: "\f4fa";
+}
+.fa-envelope-open:before {
+  content: "\f2b6";
+}
+.fa-handshake-alt-slash:before,
+.fa-handshake-simple-slash:before {
+  content: "\e05f";
+}
+.fa-mattress-pillow:before {
+  content: "\e525";
+}
+.fa-guarani-sign:before {
+  content: "\e19a";
+}
+.fa-arrows-rotate:before,
+.fa-refresh:before,
+.fa-sync:before {
+  content: "\f021";
+}
+.fa-fire-extinguisher:before {
+  content: "\f134";
+}
+.fa-cruzeiro-sign:before {
+  content: "\e152";
+}
+.fa-greater-than-equal:before {
+  content: "\f532";
+}
+.fa-shield-alt:before,
+.fa-shield-halved:before {
+  content: "\f3ed";
+}
+.fa-atlas:before,
+.fa-book-atlas:before {
+  content: "\f558";
+}
+.fa-virus:before {
+  content: "\e074";
+}
+.fa-envelope-circle-check:before {
+  content: "\e4e8";
+}
+.fa-layer-group:before {
+  content: "\f5fd";
+}
+.fa-arrows-to-dot:before {
+  content: "\e4be";
+}
+.fa-archway:before {
+  content: "\f557";
+}
+.fa-heart-circle-check:before {
+  content: "\e4fd";
+}
+.fa-house-chimney-crack:before,
+.fa-house-damage:before {
+  content: "\f6f1";
+}
+.fa-file-archive:before,
+.fa-file-zipper:before {
+  content: "\f1c6";
+}
+.fa-square:before {
+  content: "\f0c8";
+}
+.fa-glass-martini:before,
+.fa-martini-glass-empty:before {
+  content: "\f000";
+}
+.fa-couch:before {
+  content: "\f4b8";
+}
+.fa-cedi-sign:before {
+  content: "\e0df";
+}
+.fa-italic:before {
+  content: "\f033";
+}
+.fa-church:before {
+  content: "\f51d";
+}
+.fa-comments-dollar:before {
+  content: "\f653";
+}
+.fa-democrat:before {
+  content: "\f747";
+}
+.fa-z:before {
+  content: "\5a";
+}
+.fa-person-skiing:before,
+.fa-skiing:before {
+  content: "\f7c9";
+}
+.fa-road-lock:before {
+  content: "\e567";
+}
+.fa-a:before {
+  content: "\41";
+}
+.fa-temperature-arrow-down:before,
+.fa-temperature-down:before {
+  content: "\e03f";
+}
+.fa-feather-alt:before,
+.fa-feather-pointed:before {
+  content: "\f56b";
+}
+.fa-p:before {
+  content: "\50";
+}
+.fa-snowflake:before {
+  content: "\f2dc";
+}
+.fa-newspaper:before {
+  content: "\f1ea";
+}
+.fa-ad:before,
+.fa-rectangle-ad:before {
+  content: "\f641";
+}
+.fa-arrow-circle-right:before,
+.fa-circle-arrow-right:before {
+  content: "\f0a9";
+}
+.fa-filter-circle-xmark:before {
+  content: "\e17b";
+}
+.fa-locust:before {
+  content: "\e520";
+}
+.fa-sort:before,
+.fa-unsorted:before {
+  content: "\f0dc";
+}
+.fa-list-1-2:before,
+.fa-list-numeric:before,
+.fa-list-ol:before {
+  content: "\f0cb";
+}
+.fa-person-dress-burst:before {
+  content: "\e544";
+}
+.fa-money-check-alt:before,
+.fa-money-check-dollar:before {
+  content: "\f53d";
+}
+.fa-vector-square:before {
+  content: "\f5cb";
+}
+.fa-bread-slice:before {
+  content: "\f7ec";
+}
+.fa-language:before {
+  content: "\f1ab";
+}
+.fa-face-kiss-wink-heart:before,
+.fa-kiss-wink-heart:before {
+  content: "\f598";
+}
+.fa-filter:before {
+  content: "\f0b0";
+}
+.fa-question:before {
+  content: "\3f";
+}
+.fa-file-signature:before {
+  content: "\f573";
+}
+.fa-arrows-alt:before,
+.fa-up-down-left-right:before {
+  content: "\f0b2";
+}
+.fa-house-chimney-user:before {
+  content: "\e065";
+}
+.fa-hand-holding-heart:before {
+  content: "\f4be";
+}
+.fa-puzzle-piece:before {
+  content: "\f12e";
+}
+.fa-money-check:before {
+  content: "\f53c";
+}
+.fa-star-half-alt:before,
+.fa-star-half-stroke:before {
+  content: "\f5c0";
+}
+.fa-code:before {
+  content: "\f121";
+}
+.fa-glass-whiskey:before,
+.fa-whiskey-glass:before {
+  content: "\f7a0";
+}
+.fa-building-circle-exclamation:before {
+  content: "\e4d3";
+}
+.fa-magnifying-glass-chart:before {
+  content: "\e522";
+}
+.fa-arrow-up-right-from-square:before,
+.fa-external-link:before {
+  content: "\f08e";
+}
+.fa-cubes-stacked:before {
+  content: "\e4e6";
+}
+.fa-krw:before,
+.fa-won-sign:before,
+.fa-won:before {
+  content: "\f159";
+}
+.fa-virus-covid:before {
+  content: "\e4a8";
+}
+.fa-austral-sign:before {
+  content: "\e0a9";
+}
+.fa-f:before {
+  content: "\46";
+}
+.fa-leaf:before {
+  content: "\f06c";
+}
+.fa-road:before {
+  content: "\f018";
+}
+.fa-cab:before,
+.fa-taxi:before {
+  content: "\f1ba";
+}
+.fa-person-circle-plus:before {
+  content: "\e541";
+}
+.fa-chart-pie:before,
+.fa-pie-chart:before {
+  content: "\f200";
+}
+.fa-bolt-lightning:before {
+  content: "\e0b7";
+}
+.fa-sack-xmark:before {
+  content: "\e56a";
+}
+.fa-file-excel:before {
+  content: "\f1c3";
+}
+.fa-file-contract:before {
+  content: "\f56c";
+}
+.fa-fish-fins:before {
+  content: "\e4f2";
+}
+.fa-building-flag:before {
+  content: "\e4d5";
+}
+.fa-face-grin-beam:before,
+.fa-grin-beam:before {
+  content: "\f582";
+}
+.fa-object-ungroup:before {
+  content: "\f248";
+}
+.fa-poop:before {
+  content: "\f619";
+}
+.fa-location-pin:before,
+.fa-map-marker:before {
+  content: "\f041";
+}
+.fa-kaaba:before {
+  content: "\f66b";
+}
+.fa-toilet-paper:before {
+  content: "\f71e";
+}
+.fa-hard-hat:before,
+.fa-hat-hard:before,
+.fa-helmet-safety:before {
+  content: "\f807";
+}
+.fa-eject:before {
+  content: "\f052";
+}
+.fa-arrow-alt-circle-right:before,
+.fa-circle-right:before {
+  content: "\f35a";
+}
+.fa-plane-circle-check:before {
+  content: "\e555";
+}
+.fa-face-rolling-eyes:before,
+.fa-meh-rolling-eyes:before {
+  content: "\f5a5";
+}
+.fa-object-group:before {
+  content: "\f247";
+}
+.fa-chart-line:before,
+.fa-line-chart:before {
+  content: "\f201";
+}
+.fa-mask-ventilator:before {
+  content: "\e524";
+}
+.fa-arrow-right:before {
+  content: "\f061";
+}
+.fa-map-signs:before,
+.fa-signs-post:before {
+  content: "\f277";
+}
+.fa-cash-register:before {
+  content: "\f788";
+}
+.fa-person-circle-question:before {
+  content: "\e542";
+}
+.fa-h:before {
+  content: "\48";
+}
+.fa-tarp:before {
+  content: "\e57b";
+}
+.fa-screwdriver-wrench:before,
+.fa-tools:before {
+  content: "\f7d9";
+}
+.fa-arrows-to-eye:before {
+  content: "\e4bf";
+}
+.fa-plug-circle-bolt:before {
+  content: "\e55b";
+}
+.fa-heart:before {
+  content: "\f004";
+}
+.fa-mars-and-venus:before {
+  content: "\f224";
+}
+.fa-home-user:before,
+.fa-house-user:before {
+  content: "\e1b0";
+}
+.fa-dumpster-fire:before {
+  content: "\f794";
+}
+.fa-house-crack:before {
+  content: "\e3b1";
+}
+.fa-cocktail:before,
+.fa-martini-glass-citrus:before {
+  content: "\f561";
+}
+.fa-face-surprise:before,
+.fa-surprise:before {
+  content: "\f5c2";
+}
+.fa-bottle-water:before {
+  content: "\e4c5";
+}
+.fa-circle-pause:before,
+.fa-pause-circle:before {
+  content: "\f28b";
+}
+.fa-toilet-paper-slash:before {
+  content: "\e072";
+}
+.fa-apple-alt:before,
+.fa-apple-whole:before {
+  content: "\f5d1";
+}
+.fa-kitchen-set:before {
+  content: "\e51a";
+}
+.fa-r:before {
+  content: "\52";
+}
+.fa-temperature-1:before,
+.fa-temperature-quarter:before,
+.fa-thermometer-1:before,
+.fa-thermometer-quarter:before {
+  content: "\f2ca";
+}
+.fa-cube:before {
+  content: "\f1b2";
+}
+.fa-bitcoin-sign:before {
+  content: "\e0b4";
+}
+.fa-shield-dog:before {
+  content: "\e573";
+}
+.fa-solar-panel:before {
+  content: "\f5ba";
+}
+.fa-lock-open:before {
+  content: "\f3c1";
+}
+.fa-elevator:before {
+  content: "\e16d";
+}
+.fa-money-bill-transfer:before {
+  content: "\e528";
+}
+.fa-money-bill-trend-up:before {
+  content: "\e529";
+}
+.fa-house-flood-water-circle-arrow-right:before {
+  content: "\e50f";
+}
+.fa-poll-h:before,
+.fa-square-poll-horizontal:before {
+  content: "\f682";
+}
+.fa-circle:before {
+  content: "\f111";
+}
+.fa-backward-fast:before,
+.fa-fast-backward:before {
+  content: "\f049";
+}
+.fa-recycle:before {
+  content: "\f1b8";
+}
+.fa-user-astronaut:before {
+  content: "\f4fb";
+}
+.fa-plane-slash:before {
+  content: "\e069";
+}
+.fa-trademark:before {
+  content: "\f25c";
+}
+.fa-basketball-ball:before,
+.fa-basketball:before {
+  content: "\f434";
+}
+.fa-satellite-dish:before {
+  content: "\f7c0";
+}
+.fa-arrow-alt-circle-up:before,
+.fa-circle-up:before {
+  content: "\f35b";
+}
+.fa-mobile-alt:before,
+.fa-mobile-screen-button:before {
+  content: "\f3cd";
+}
+.fa-volume-high:before,
+.fa-volume-up:before {
+  content: "\f028";
+}
+.fa-users-rays:before {
+  content: "\e593";
+}
+.fa-wallet:before {
+  content: "\f555";
+}
+.fa-clipboard-check:before {
+  content: "\f46c";
+}
+.fa-file-audio:before {
+  content: "\f1c7";
+}
+.fa-burger:before,
+.fa-hamburger:before {
+  content: "\f805";
+}
+.fa-wrench:before {
+  content: "\f0ad";
+}
+.fa-bugs:before {
+  content: "\e4d0";
+}
+.fa-rupee-sign:before,
+.fa-rupee:before {
+  content: "\f156";
+}
+.fa-file-image:before {
+  content: "\f1c5";
+}
+.fa-circle-question:before,
+.fa-question-circle:before {
+  content: "\f059";
+}
+.fa-plane-departure:before {
+  content: "\f5b0";
+}
+.fa-handshake-slash:before {
+  content: "\e060";
+}
+.fa-book-bookmark:before {
+  content: "\e0bb";
+}
+.fa-code-branch:before {
+  content: "\f126";
+}
+.fa-hat-cowboy:before {
+  content: "\f8c0";
+}
+.fa-bridge:before {
+  content: "\e4c8";
+}
+.fa-phone-alt:before,
+.fa-phone-flip:before {
+  content: "\f879";
+}
+.fa-truck-front:before {
+  content: "\e2b7";
+}
+.fa-cat:before {
+  content: "\f6be";
+}
+.fa-anchor-circle-exclamation:before {
+  content: "\e4ab";
+}
+.fa-truck-field:before {
+  content: "\e58d";
+}
+.fa-route:before {
+  content: "\f4d7";
+}
+.fa-clipboard-question:before {
+  content: "\e4e3";
+}
+.fa-panorama:before {
+  content: "\e209";
+}
+.fa-comment-medical:before {
+  content: "\f7f5";
+}
+.fa-teeth-open:before {
+  content: "\f62f";
+}
+.fa-file-circle-minus:before {
+  content: "\e4ed";
+}
+.fa-tags:before {
+  content: "\f02c";
+}
+.fa-wine-glass:before {
+  content: "\f4e3";
+}
+.fa-fast-forward:before,
+.fa-forward-fast:before {
+  content: "\f050";
+}
+.fa-face-meh-blank:before,
+.fa-meh-blank:before {
+  content: "\f5a4";
+}
+.fa-parking:before,
+.fa-square-parking:before {
+  content: "\f540";
+}
+.fa-house-signal:before {
+  content: "\e012";
+}
+.fa-bars-progress:before,
+.fa-tasks-alt:before {
+  content: "\f828";
+}
+.fa-faucet-drip:before {
+  content: "\e006";
+}
+.fa-cart-flatbed:before,
+.fa-dolly-flatbed:before {
+  content: "\f474";
+}
+.fa-ban-smoking:before,
+.fa-smoking-ban:before {
+  content: "\f54d";
+}
+.fa-terminal:before {
+  content: "\f120";
+}
+.fa-mobile-button:before {
+  content: "\f10b";
+}
+.fa-house-medical-flag:before {
+  content: "\e514";
+}
+.fa-basket-shopping:before,
+.fa-shopping-basket:before {
+  content: "\f291";
+}
+.fa-tape:before {
+  content: "\f4db";
+}
+.fa-bus-alt:before,
+.fa-bus-simple:before {
+  content: "\f55e";
+}
+.fa-eye:before {
+  content: "\f06e";
+}
+.fa-face-sad-cry:before,
+.fa-sad-cry:before {
+  content: "\f5b3";
+}
+.fa-audio-description:before {
+  content: "\f29e";
+}
+.fa-person-military-to-person:before {
+  content: "\e54c";
+}
+.fa-file-shield:before {
+  content: "\e4f0";
+}
+.fa-user-slash:before {
+  content: "\f506";
+}
+.fa-pen:before {
+  content: "\f304";
+}
+.fa-tower-observation:before {
+  content: "\e586";
+}
+.fa-file-code:before {
+  content: "\f1c9";
+}
+.fa-signal-5:before,
+.fa-signal-perfect:before,
+.fa-signal:before {
+  content: "\f012";
+}
+.fa-bus:before {
+  content: "\f207";
+}
+.fa-heart-circle-xmark:before {
+  content: "\e501";
+}
+.fa-home-lg:before,
+.fa-house-chimney:before {
+  content: "\e3af";
+}
+.fa-window-maximize:before {
+  content: "\f2d0";
+}
+.fa-face-frown:before,
+.fa-frown:before {
+  content: "\f119";
+}
+.fa-prescription:before {
+  content: "\f5b1";
+}
+.fa-shop:before,
+.fa-store-alt:before {
+  content: "\f54f";
+}
+.fa-floppy-disk:before,
+.fa-save:before {
+  content: "\f0c7";
+}
+.fa-vihara:before {
+  content: "\f6a7";
+}
+.fa-balance-scale-left:before,
+.fa-scale-unbalanced:before {
+  content: "\f515";
+}
+.fa-sort-asc:before,
+.fa-sort-up:before {
+  content: "\f0de";
+}
+.fa-comment-dots:before,
+.fa-commenting:before {
+  content: "\f4ad";
+}
+.fa-plant-wilt:before {
+  content: "\e5aa";
+}
+.fa-diamond:before {
+  content: "\f219";
+}
+.fa-face-grin-squint:before,
+.fa-grin-squint:before {
+  content: "\f585";
+}
+.fa-hand-holding-dollar:before,
+.fa-hand-holding-usd:before {
+  content: "\f4c0";
+}
+.fa-bacterium:before {
+  content: "\e05a";
+}
+.fa-hand-pointer:before {
+  content: "\f25a";
+}
+.fa-drum-steelpan:before {
+  content: "\f56a";
+}
+.fa-hand-scissors:before {
+  content: "\f257";
+}
+.fa-hands-praying:before,
+.fa-praying-hands:before {
+  content: "\f684";
+}
+.fa-arrow-right-rotate:before,
+.fa-arrow-rotate-forward:before,
+.fa-arrow-rotate-right:before,
+.fa-redo:before {
+  content: "\f01e";
+}
+.fa-biohazard:before {
+  content: "\f780";
+}
+.fa-location-crosshairs:before,
+.fa-location:before {
+  content: "\f601";
+}
+.fa-mars-double:before {
+  content: "\f227";
+}
+.fa-child-dress:before {
+  content: "\e59c";
+}
+.fa-users-between-lines:before {
+  content: "\e591";
+}
+.fa-lungs-virus:before {
+  content: "\e067";
+}
+.fa-face-grin-tears:before,
+.fa-grin-tears:before {
+  content: "\f588";
+}
+.fa-phone:before {
+  content: "\f095";
+}
+.fa-calendar-times:before,
+.fa-calendar-xmark:before {
+  content: "\f273";
+}
+.fa-child-reaching:before {
+  content: "\e59d";
+}
+.fa-head-side-virus:before {
+  content: "\e064";
+}
+.fa-user-cog:before,
+.fa-user-gear:before {
+  content: "\f4fe";
+}
+.fa-arrow-up-1-9:before,
+.fa-sort-numeric-up:before {
+  content: "\f163";
+}
+.fa-door-closed:before {
+  content: "\f52a";
+}
+.fa-shield-virus:before {
+  content: "\e06c";
+}
+.fa-dice-six:before {
+  content: "\f526";
+}
+.fa-mosquito-net:before {
+  content: "\e52c";
+}
+.fa-bridge-water:before {
+  content: "\e4ce";
+}
+.fa-person-booth:before {
+  content: "\f756";
+}
+.fa-text-width:before {
+  content: "\f035";
+}
+.fa-hat-wizard:before {
+  content: "\f6e8";
+}
+.fa-pen-fancy:before {
+  content: "\f5ac";
+}
+.fa-digging:before,
+.fa-person-digging:before {
+  content: "\f85e";
+}
+.fa-trash:before {
+  content: "\f1f8";
+}
+.fa-gauge-simple-med:before,
+.fa-gauge-simple:before,
+.fa-tachometer-average:before {
+  content: "\f629";
+}
+.fa-book-medical:before {
+  content: "\f7e6";
+}
+.fa-poo:before {
+  content: "\f2fe";
+}
+.fa-quote-right-alt:before,
+.fa-quote-right:before {
+  content: "\f10e";
+}
+.fa-shirt:before,
+.fa-t-shirt:before,
+.fa-tshirt:before {
+  content: "\f553";
+}
+.fa-cubes:before {
+  content: "\f1b3";
+}
+.fa-divide:before {
+  content: "\f529";
+}
+.fa-tenge-sign:before,
+.fa-tenge:before {
+  content: "\f7d7";
+}
+.fa-headphones:before {
+  content: "\f025";
+}
+.fa-hands-holding:before {
+  content: "\f4c2";
+}
+.fa-hands-clapping:before {
+  content: "\e1a8";
+}
+.fa-republican:before {
+  content: "\f75e";
+}
+.fa-arrow-left:before {
+  content: "\f060";
+}
+.fa-person-circle-xmark:before {
+  content: "\e543";
+}
+.fa-ruler:before {
+  content: "\f545";
+}
+.fa-align-left:before {
+  content: "\f036";
+}
+.fa-dice-d6:before {
+  content: "\f6d1";
+}
+.fa-restroom:before {
+  content: "\f7bd";
+}
+.fa-j:before {
+  content: "\4a";
+}
+.fa-users-viewfinder:before {
+  content: "\e595";
+}
+.fa-file-video:before {
+  content: "\f1c8";
+}
+.fa-external-link-alt:before,
+.fa-up-right-from-square:before {
+  content: "\f35d";
+}
+.fa-table-cells:before,
+.fa-th:before {
+  content: "\f00a";
+}
+.fa-file-pdf:before {
+  content: "\f1c1";
+}
+.fa-bible:before,
+.fa-book-bible:before {
+  content: "\f647";
+}
+.fa-o:before {
+  content: "\4f";
+}
+.fa-medkit:before,
+.fa-suitcase-medical:before {
+  content: "\f0fa";
+}
+.fa-user-secret:before {
+  content: "\f21b";
+}
+.fa-otter:before {
+  content: "\f700";
+}
+.fa-female:before,
+.fa-person-dress:before {
+  content: "\f182";
+}
+.fa-comment-dollar:before {
+  content: "\f651";
+}
+.fa-briefcase-clock:before,
+.fa-business-time:before {
+  content: "\f64a";
+}
+.fa-table-cells-large:before,
+.fa-th-large:before {
+  content: "\f009";
+}
+.fa-book-tanakh:before,
+.fa-tanakh:before {
+  content: "\f827";
+}
+.fa-phone-volume:before,
+.fa-volume-control-phone:before {
+  content: "\f2a0";
+}
+.fa-hat-cowboy-side:before {
+  content: "\f8c1";
+}
+.fa-clipboard-user:before {
+  content: "\f7f3";
+}
+.fa-child:before {
+  content: "\f1ae";
+}
+.fa-lira-sign:before {
+  content: "\f195";
+}
+.fa-satellite:before {
+  content: "\f7bf";
+}
+.fa-plane-lock:before {
+  content: "\e558";
+}
+.fa-tag:before {
+  content: "\f02b";
+}
+.fa-comment:before {
+  content: "\f075";
+}
+.fa-birthday-cake:before,
+.fa-cake-candles:before,
+.fa-cake:before {
+  content: "\f1fd";
+}
+.fa-envelope:before {
+  content: "\f0e0";
+}
+.fa-angle-double-up:before,
+.fa-angles-up:before {
+  content: "\f102";
+}
+.fa-paperclip:before {
+  content: "\f0c6";
+}
+.fa-arrow-right-to-city:before {
+  content: "\e4b3";
+}
+.fa-ribbon:before {
+  content: "\f4d6";
+}
+.fa-lungs:before {
+  content: "\f604";
+}
+.fa-arrow-up-9-1:before,
+.fa-sort-numeric-up-alt:before {
+  content: "\f887";
+}
+.fa-litecoin-sign:before {
+  content: "\e1d3";
+}
+.fa-border-none:before {
+  content: "\f850";
+}
+.fa-circle-nodes:before {
+  content: "\e4e2";
+}
+.fa-parachute-box:before {
+  content: "\f4cd";
+}
+.fa-indent:before {
+  content: "\f03c";
+}
+.fa-truck-field-un:before {
+  content: "\e58e";
+}
+.fa-hourglass-empty:before,
+.fa-hourglass:before {
+  content: "\f254";
+}
+.fa-mountain:before {
+  content: "\f6fc";
+}
+.fa-user-doctor:before,
+.fa-user-md:before {
+  content: "\f0f0";
+}
+.fa-circle-info:before,
+.fa-info-circle:before {
+  content: "\f05a";
+}
+.fa-cloud-meatball:before {
+  content: "\f73b";
+}
+.fa-camera-alt:before,
+.fa-camera:before {
+  content: "\f030";
+}
+.fa-square-virus:before {
+  content: "\e578";
+}
+.fa-meteor:before {
+  content: "\f753";
+}
+.fa-car-on:before {
+  content: "\e4dd";
+}
+.fa-sleigh:before {
+  content: "\f7cc";
+}
+.fa-arrow-down-1-9:before,
+.fa-sort-numeric-asc:before,
+.fa-sort-numeric-down:before {
+  content: "\f162";
+}
+.fa-hand-holding-droplet:before,
+.fa-hand-holding-water:before {
+  content: "\f4c1";
+}
+.fa-water:before {
+  content: "\f773";
+}
+.fa-calendar-check:before {
+  content: "\f274";
+}
+.fa-braille:before {
+  content: "\f2a1";
+}
+.fa-prescription-bottle-alt:before,
+.fa-prescription-bottle-medical:before {
+  content: "\f486";
+}
+.fa-landmark:before {
+  content: "\f66f";
+}
+.fa-truck:before {
+  content: "\f0d1";
+}
+.fa-crosshairs:before {
+  content: "\f05b";
+}
+.fa-person-cane:before {
+  content: "\e53c";
+}
+.fa-tent:before {
+  content: "\e57d";
+}
+.fa-vest-patches:before {
+  content: "\e086";
+}
+.fa-check-double:before {
+  content: "\f560";
+}
+.fa-arrow-down-a-z:before,
+.fa-sort-alpha-asc:before,
+.fa-sort-alpha-down:before {
+  content: "\f15d";
+}
+.fa-money-bill-wheat:before {
+  content: "\e52a";
+}
+.fa-cookie:before {
+  content: "\f563";
+}
+.fa-arrow-left-rotate:before,
+.fa-arrow-rotate-back:before,
+.fa-arrow-rotate-backward:before,
+.fa-arrow-rotate-left:before,
+.fa-undo:before {
+  content: "\f0e2";
+}
+.fa-hard-drive:before,
+.fa-hdd:before {
+  content: "\f0a0";
+}
+.fa-face-grin-squint-tears:before,
+.fa-grin-squint-tears:before {
+  content: "\f586";
+}
+.fa-dumbbell:before {
+  content: "\f44b";
+}
+.fa-list-alt:before,
+.fa-rectangle-list:before {
+  content: "\f022";
+}
+.fa-tarp-droplet:before {
+  content: "\e57c";
+}
+.fa-house-medical-circle-check:before {
+  content: "\e511";
+}
+.fa-person-skiing-nordic:before,
+.fa-skiing-nordic:before {
+  content: "\f7ca";
+}
+.fa-calendar-plus:before {
+  content: "\f271";
+}
+.fa-plane-arrival:before {
+  content: "\f5af";
+}
+.fa-arrow-alt-circle-left:before,
+.fa-circle-left:before {
+  content: "\f359";
+}
+.fa-subway:before,
+.fa-train-subway:before {
+  content: "\f239";
+}
+.fa-chart-gantt:before {
+  content: "\e0e4";
+}
+.fa-indian-rupee-sign:before,
+.fa-indian-rupee:before,
+.fa-inr:before {
+  content: "\e1bc";
+}
+.fa-crop-alt:before,
+.fa-crop-simple:before {
+  content: "\f565";
+}
+.fa-money-bill-1:before,
+.fa-money-bill-alt:before {
+  content: "\f3d1";
+}
+.fa-left-long:before,
+.fa-long-arrow-alt-left:before {
+  content: "\f30a";
+}
+.fa-dna:before {
+  content: "\f471";
+}
+.fa-virus-slash:before {
+  content: "\e075";
+}
+.fa-minus:before,
+.fa-subtract:before {
+  content: "\f068";
+}
+.fa-chess:before {
+  content: "\f439";
+}
+.fa-arrow-left-long:before,
+.fa-long-arrow-left:before {
+  content: "\f177";
+}
+.fa-plug-circle-check:before {
+  content: "\e55c";
+}
+.fa-street-view:before {
+  content: "\f21d";
+}
+.fa-franc-sign:before {
+  content: "\e18f";
+}
+.fa-volume-off:before {
+  content: "\f026";
+}
+.fa-american-sign-language-interpreting:before,
+.fa-asl-interpreting:before,
+.fa-hands-american-sign-language-interpreting:before,
+.fa-hands-asl-interpreting:before {
+  content: "\f2a3";
+}
+.fa-cog:before,
+.fa-gear:before {
+  content: "\f013";
+}
+.fa-droplet-slash:before,
+.fa-tint-slash:before {
+  content: "\f5c7";
+}
+.fa-mosque:before {
+  content: "\f678";
+}
+.fa-mosquito:before {
+  content: "\e52b";
+}
+.fa-star-of-david:before {
+  content: "\f69a";
+}
+.fa-person-military-rifle:before {
+  content: "\e54b";
+}
+.fa-cart-shopping:before,
+.fa-shopping-cart:before {
+  content: "\f07a";
+}
+.fa-vials:before {
+  content: "\f493";
+}
+.fa-plug-circle-plus:before {
+  content: "\e55f";
+}
+.fa-place-of-worship:before {
+  content: "\f67f";
+}
+.fa-grip-vertical:before {
+  content: "\f58e";
+}
+.fa-arrow-turn-up:before,
+.fa-level-up:before {
+  content: "\f148";
+}
+.fa-u:before {
+  content: "\55";
+}
+.fa-square-root-alt:before,
+.fa-square-root-variable:before {
+  content: "\f698";
+}
+.fa-clock-four:before,
+.fa-clock:before {
+  content: "\f017";
+}
+.fa-backward-step:before,
+.fa-step-backward:before {
+  content: "\f048";
+}
+.fa-pallet:before {
+  content: "\f482";
+}
+.fa-faucet:before {
+  content: "\e005";
+}
+.fa-baseball-bat-ball:before {
+  content: "\f432";
+}
+.fa-s:before {
+  content: "\53";
+}
+.fa-timeline:before {
+  content: "\e29c";
+}
+.fa-keyboard:before {
+  content: "\f11c";
+}
+.fa-caret-down:before {
+  content: "\f0d7";
+}
+.fa-clinic-medical:before,
+.fa-house-chimney-medical:before {
+  content: "\f7f2";
+}
+.fa-temperature-3:before,
+.fa-temperature-three-quarters:before,
+.fa-thermometer-3:before,
+.fa-thermometer-three-quarters:before {
+  content: "\f2c8";
+}
+.fa-mobile-android-alt:before,
+.fa-mobile-screen:before {
+  content: "\f3cf";
+}
+.fa-plane-up:before {
+  content: "\e22d";
+}
+.fa-piggy-bank:before {
+  content: "\f4d3";
+}
+.fa-battery-3:before,
+.fa-battery-half:before {
+  content: "\f242";
+}
+.fa-mountain-city:before {
+  content: "\e52e";
+}
+.fa-coins:before {
+  content: "\f51e";
+}
+.fa-khanda:before {
+  content: "\f66d";
+}
+.fa-sliders-h:before,
+.fa-sliders:before {
+  content: "\f1de";
+}
+.fa-folder-tree:before {
+  content: "\f802";
+}
+.fa-network-wired:before {
+  content: "\f6ff";
+}
+.fa-map-pin:before {
+  content: "\f276";
+}
+.fa-hamsa:before {
+  content: "\f665";
+}
+.fa-cent-sign:before {
+  content: "\e3f5";
+}
+.fa-flask:before {
+  content: "\f0c3";
+}
+.fa-person-pregnant:before {
+  content: "\e31e";
+}
+.fa-wand-sparkles:before {
+  content: "\f72b";
+}
+.fa-ellipsis-v:before,
+.fa-ellipsis-vertical:before {
+  content: "\f142";
+}
+.fa-ticket:before {
+  content: "\f145";
+}
+.fa-power-off:before {
+  content: "\f011";
+}
+.fa-long-arrow-alt-right:before,
+.fa-right-long:before {
+  content: "\f30b";
+}
+.fa-flag-usa:before {
+  content: "\f74d";
+}
+.fa-laptop-file:before {
+  content: "\e51d";
+}
+.fa-teletype:before,
+.fa-tty:before {
+  content: "\f1e4";
+}
+.fa-diagram-next:before {
+  content: "\e476";
+}
+.fa-person-rifle:before {
+  content: "\e54e";
+}
+.fa-house-medical-circle-exclamation:before {
+  content: "\e512";
+}
+.fa-closed-captioning:before {
+  content: "\f20a";
+}
+.fa-hiking:before,
+.fa-person-hiking:before {
+  content: "\f6ec";
+}
+.fa-venus-double:before {
+  content: "\f226";
+}
+.fa-images:before {
+  content: "\f302";
+}
+.fa-calculator:before {
+  content: "\f1ec";
+}
+.fa-people-pulling:before {
+  content: "\e535";
+}
+.fa-n:before {
+  content: "\4e";
+}
+.fa-cable-car:before,
+.fa-tram:before {
+  content: "\f7da";
+}
+.fa-cloud-rain:before {
+  content: "\f73d";
+}
+.fa-building-circle-xmark:before {
+  content: "\e4d4";
+}
+.fa-ship:before {
+  content: "\f21a";
+}
+.fa-arrows-down-to-line:before {
+  content: "\e4b8";
+}
+.fa-download:before {
+  content: "\f019";
+}
+.fa-face-grin:before,
+.fa-grin:before {
+  content: "\f580";
+}
+.fa-backspace:before,
+.fa-delete-left:before {
+  content: "\f55a";
+}
+.fa-eye-dropper-empty:before,
+.fa-eye-dropper:before,
+.fa-eyedropper:before {
+  content: "\f1fb";
+}
+.fa-file-circle-check:before {
+  content: "\e5a0";
+}
+.fa-forward:before {
+  content: "\f04e";
+}
+.fa-mobile-android:before,
+.fa-mobile-phone:before,
+.fa-mobile:before {
+  content: "\f3ce";
+}
+.fa-face-meh:before,
+.fa-meh:before {
+  content: "\f11a";
+}
+.fa-align-center:before {
+  content: "\f037";
+}
+.fa-book-dead:before,
+.fa-book-skull:before {
+  content: "\f6b7";
+}
+.fa-drivers-license:before,
+.fa-id-card:before {
+  content: "\f2c2";
+}
+.fa-dedent:before,
+.fa-outdent:before {
+  content: "\f03b";
+}
+.fa-heart-circle-exclamation:before {
+  content: "\e4fe";
+}
+.fa-home-alt:before,
+.fa-home-lg-alt:before,
+.fa-home:before,
+.fa-house:before {
+  content: "\f015";
+}
+.fa-calendar-week:before {
+  content: "\f784";
+}
+.fa-laptop-medical:before {
+  content: "\f812";
+}
+.fa-b:before {
+  content: "\42";
+}
+.fa-file-medical:before {
+  content: "\f477";
+}
+.fa-dice-one:before {
+  content: "\f525";
+}
+.fa-kiwi-bird:before {
+  content: "\f535";
+}
+.fa-arrow-right-arrow-left:before,
+.fa-exchange:before {
+  content: "\f0ec";
+}
+.fa-redo-alt:before,
+.fa-rotate-forward:before,
+.fa-rotate-right:before {
+  content: "\f2f9";
+}
+.fa-cutlery:before,
+.fa-utensils:before {
+  content: "\f2e7";
+}
+.fa-arrow-up-wide-short:before,
+.fa-sort-amount-up:before {
+  content: "\f161";
+}
+.fa-mill-sign:before {
+  content: "\e1ed";
+}
+.fa-bowl-rice:before {
+  content: "\e2eb";
+}
+.fa-skull:before {
+  content: "\f54c";
+}
+.fa-broadcast-tower:before,
+.fa-tower-broadcast:before {
+  content: "\f519";
+}
+.fa-truck-pickup:before {
+  content: "\f63c";
+}
+.fa-long-arrow-alt-up:before,
+.fa-up-long:before {
+  content: "\f30c";
+}
+.fa-stop:before {
+  content: "\f04d";
+}
+.fa-code-merge:before {
+  content: "\f387";
+}
+.fa-upload:before {
+  content: "\f093";
+}
+.fa-hurricane:before {
+  content: "\f751";
+}
+.fa-mound:before {
+  content: "\e52d";
+}
+.fa-toilet-portable:before {
+  content: "\e583";
+}
+.fa-compact-disc:before {
+  content: "\f51f";
+}
+.fa-file-arrow-down:before,
+.fa-file-download:before {
+  content: "\f56d";
+}
+.fa-caravan:before {
+  content: "\f8ff";
+}
+.fa-shield-cat:before {
+  content: "\e572";
+}
+.fa-bolt:before,
+.fa-zap:before {
+  content: "\f0e7";
+}
+.fa-glass-water:before {
+  content: "\e4f4";
+}
+.fa-oil-well:before {
+  content: "\e532";
+}
+.fa-vault:before {
+  content: "\e2c5";
+}
+.fa-mars:before {
+  content: "\f222";
+}
+.fa-toilet:before {
+  content: "\f7d8";
+}
+.fa-plane-circle-xmark:before {
+  content: "\e557";
+}
+.fa-cny:before,
+.fa-jpy:before,
+.fa-rmb:before,
+.fa-yen-sign:before,
+.fa-yen:before {
+  content: "\f157";
+}
+.fa-rouble:before,
+.fa-rub:before,
+.fa-ruble-sign:before,
+.fa-ruble:before {
+  content: "\f158";
+}
+.fa-sun:before {
+  content: "\f185";
+}
+.fa-guitar:before {
+  content: "\f7a6";
+}
+.fa-face-laugh-wink:before,
+.fa-laugh-wink:before {
+  content: "\f59c";
+}
+.fa-horse-head:before {
+  content: "\f7ab";
+}
+.fa-bore-hole:before {
+  content: "\e4c3";
+}
+.fa-industry:before {
+  content: "\f275";
+}
+.fa-arrow-alt-circle-down:before,
+.fa-circle-down:before {
+  content: "\f358";
+}
+.fa-arrows-turn-to-dots:before {
+  content: "\e4c1";
+}
+.fa-florin-sign:before {
+  content: "\e184";
+}
+.fa-arrow-down-short-wide:before,
+.fa-sort-amount-desc:before,
+.fa-sort-amount-down-alt:before {
+  content: "\f884";
+}
+.fa-less-than:before {
+  content: "\3c";
+}
+.fa-angle-down:before {
+  content: "\f107";
+}
+.fa-car-tunnel:before {
+  content: "\e4de";
+}
+.fa-head-side-cough:before {
+  content: "\e061";
+}
+.fa-grip-lines:before {
+  content: "\f7a4";
+}
+.fa-thumbs-down:before {
+  content: "\f165";
+}
+.fa-user-lock:before {
+  content: "\f502";
+}
+.fa-arrow-right-long:before,
+.fa-long-arrow-right:before {
+  content: "\f178";
+}
+.fa-anchor-circle-xmark:before {
+  content: "\e4ac";
+}
+.fa-ellipsis-h:before,
+.fa-ellipsis:before {
+  content: "\f141";
+}
+.fa-chess-pawn:before {
+  content: "\f443";
+}
+.fa-first-aid:before,
+.fa-kit-medical:before {
+  content: "\f479";
+}
+.fa-person-through-window:before {
+  content: "\e5a9";
+}
+.fa-toolbox:before {
+  content: "\f552";
+}
+.fa-hands-holding-circle:before {
+  content: "\e4fb";
+}
+.fa-bug:before {
+  content: "\f188";
+}
+.fa-credit-card-alt:before,
+.fa-credit-card:before {
+  content: "\f09d";
+}
+.fa-automobile:before,
+.fa-car:before {
+  content: "\f1b9";
+}
+.fa-hand-holding-hand:before {
+  content: "\e4f7";
+}
+.fa-book-open-reader:before,
+.fa-book-reader:before {
+  content: "\f5da";
+}
+.fa-mountain-sun:before {
+  content: "\e52f";
+}
+.fa-arrows-left-right-to-line:before {
+  content: "\e4ba";
+}
+.fa-dice-d20:before {
+  content: "\f6cf";
+}
+.fa-truck-droplet:before {
+  content: "\e58c";
+}
+.fa-file-circle-xmark:before {
+  content: "\e5a1";
+}
+.fa-temperature-arrow-up:before,
+.fa-temperature-up:before {
+  content: "\e040";
+}
+.fa-medal:before {
+  content: "\f5a2";
+}
+.fa-bed:before {
+  content: "\f236";
+}
+.fa-h-square:before,
+.fa-square-h:before {
+  content: "\f0fd";
+}
+.fa-podcast:before {
+  content: "\f2ce";
+}
+.fa-temperature-4:before,
+.fa-temperature-full:before,
+.fa-thermometer-4:before,
+.fa-thermometer-full:before {
+  content: "\f2c7";
+}
+.fa-bell:before {
+  content: "\f0f3";
+}
+.fa-superscript:before {
+  content: "\f12b";
+}
+.fa-plug-circle-xmark:before {
+  content: "\e560";
+}
+.fa-star-of-life:before {
+  content: "\f621";
+}
+.fa-phone-slash:before {
+  content: "\f3dd";
+}
+.fa-paint-roller:before {
+  content: "\f5aa";
+}
+.fa-hands-helping:before,
+.fa-handshake-angle:before {
+  content: "\f4c4";
+}
+.fa-location-dot:before,
+.fa-map-marker-alt:before {
+  content: "\f3c5";
+}
+.fa-file:before {
+  content: "\f15b";
+}
+.fa-greater-than:before {
+  content: "\3e";
+}
+.fa-person-swimming:before,
+.fa-swimmer:before {
+  content: "\f5c4";
+}
+.fa-arrow-down:before {
+  content: "\f063";
+}
+.fa-droplet:before,
+.fa-tint:before {
+  content: "\f043";
+}
+.fa-eraser:before {
+  content: "\f12d";
+}
+.fa-earth-america:before,
+.fa-earth-americas:before,
+.fa-earth:before,
+.fa-globe-americas:before {
+  content: "\f57d";
+}
+.fa-person-burst:before {
+  content: "\e53b";
+}
+.fa-dove:before {
+  content: "\f4ba";
+}
+.fa-battery-0:before,
+.fa-battery-empty:before {
+  content: "\f244";
+}
+.fa-socks:before {
+  content: "\f696";
+}
+.fa-inbox:before {
+  content: "\f01c";
+}
+.fa-section:before {
+  content: "\e447";
+}
+.fa-gauge-high:before,
+.fa-tachometer-alt-fast:before,
+.fa-tachometer-alt:before {
+  content: "\f625";
+}
+.fa-envelope-open-text:before {
+  content: "\f658";
+}
+.fa-hospital-alt:before,
+.fa-hospital-wide:before,
+.fa-hospital:before {
+  content: "\f0f8";
+}
+.fa-wine-bottle:before {
+  content: "\f72f";
+}
+.fa-chess-rook:before {
+  content: "\f447";
+}
+.fa-bars-staggered:before,
+.fa-reorder:before,
+.fa-stream:before {
+  content: "\f550";
+}
+.fa-dharmachakra:before {
+  content: "\f655";
+}
+.fa-hotdog:before {
+  content: "\f80f";
+}
+.fa-blind:before,
+.fa-person-walking-with-cane:before {
+  content: "\f29d";
+}
+.fa-drum:before {
+  content: "\f569";
+}
+.fa-ice-cream:before {
+  content: "\f810";
+}
+.fa-heart-circle-bolt:before {
+  content: "\e4fc";
+}
+.fa-fax:before {
+  content: "\f1ac";
+}
+.fa-paragraph:before {
+  content: "\f1dd";
+}
+.fa-check-to-slot:before,
+.fa-vote-yea:before {
+  content: "\f772";
+}
+.fa-star-half:before {
+  content: "\f089";
+}
+.fa-boxes-alt:before,
+.fa-boxes-stacked:before,
+.fa-boxes:before {
+  content: "\f468";
+}
+.fa-chain:before,
+.fa-link:before {
+  content: "\f0c1";
+}
+.fa-assistive-listening-systems:before,
+.fa-ear-listen:before {
+  content: "\f2a2";
+}
+.fa-tree-city:before {
+  content: "\e587";
+}
+.fa-play:before {
+  content: "\f04b";
+}
+.fa-font:before {
+  content: "\f031";
+}
+.fa-rupiah-sign:before {
+  content: "\e23d";
+}
+.fa-magnifying-glass:before,
+.fa-search:before {
+  content: "\f002";
+}
+.fa-ping-pong-paddle-ball:before,
+.fa-table-tennis-paddle-ball:before,
+.fa-table-tennis:before {
+  content: "\f45d";
+}
+.fa-diagnoses:before,
+.fa-person-dots-from-line:before {
+  content: "\f470";
+}
+.fa-trash-can-arrow-up:before,
+.fa-trash-restore-alt:before {
+  content: "\f82a";
+}
+.fa-naira-sign:before {
+  content: "\e1f6";
+}
+.fa-cart-arrow-down:before {
+  content: "\f218";
+}
+.fa-walkie-talkie:before {
+  content: "\f8ef";
+}
+.fa-file-edit:before,
+.fa-file-pen:before {
+  content: "\f31c";
+}
+.fa-receipt:before {
+  content: "\f543";
+}
+.fa-pen-square:before,
+.fa-pencil-square:before,
+.fa-square-pen:before {
+  content: "\f14b";
+}
+.fa-suitcase-rolling:before {
+  content: "\f5c1";
+}
+.fa-person-circle-exclamation:before {
+  content: "\e53f";
+}
+.fa-chevron-down:before {
+  content: "\f078";
+}
+.fa-battery-5:before,
+.fa-battery-full:before,
+.fa-battery:before {
+  content: "\f240";
+}
+.fa-skull-crossbones:before {
+  content: "\f714";
+}
+.fa-code-compare:before {
+  content: "\e13a";
+}
+.fa-list-dots:before,
+.fa-list-ul:before {
+  content: "\f0ca";
+}
+.fa-school-lock:before {
+  content: "\e56f";
+}
+.fa-tower-cell:before {
+  content: "\e585";
+}
+.fa-down-long:before,
+.fa-long-arrow-alt-down:before {
+  content: "\f309";
+}
+.fa-ranking-star:before {
+  content: "\e561";
+}
+.fa-chess-king:before {
+  content: "\f43f";
+}
+.fa-person-harassing:before {
+  content: "\e549";
+}
+.fa-brazilian-real-sign:before {
+  content: "\e46c";
+}
+.fa-landmark-alt:before,
+.fa-landmark-dome:before {
+  content: "\f752";
+}
+.fa-arrow-up:before {
+  content: "\f062";
+}
+.fa-television:before,
+.fa-tv-alt:before,
+.fa-tv:before {
+  content: "\f26c";
+}
+.fa-shrimp:before {
+  content: "\e448";
+}
+.fa-list-check:before,
+.fa-tasks:before {
+  content: "\f0ae";
+}
+.fa-jug-detergent:before {
+  content: "\e519";
+}
+.fa-circle-user:before,
+.fa-user-circle:before {
+  content: "\f2bd";
+}
+.fa-user-shield:before {
+  content: "\f505";
+}
+.fa-wind:before {
+  content: "\f72e";
+}
+.fa-car-burst:before,
+.fa-car-crash:before {
+  content: "\f5e1";
+}
+.fa-y:before {
+  content: "\59";
+}
+.fa-person-snowboarding:before,
+.fa-snowboarding:before {
+  content: "\f7ce";
+}
+.fa-shipping-fast:before,
+.fa-truck-fast:before {
+  content: "\f48b";
+}
+.fa-fish:before {
+  content: "\f578";
+}
+.fa-user-graduate:before {
+  content: "\f501";
+}
+.fa-adjust:before,
+.fa-circle-half-stroke:before {
+  content: "\f042";
+}
+.fa-clapperboard:before {
+  content: "\e131";
+}
+.fa-circle-radiation:before,
+.fa-radiation-alt:before {
+  content: "\f7ba";
+}
+.fa-baseball-ball:before,
+.fa-baseball:before {
+  content: "\f433";
+}
+.fa-jet-fighter-up:before {
+  content: "\e518";
+}
+.fa-diagram-project:before,
+.fa-project-diagram:before {
+  content: "\f542";
+}
+.fa-copy:before {
+  content: "\f0c5";
+}
+.fa-volume-mute:before,
+.fa-volume-times:before,
+.fa-volume-xmark:before {
+  content: "\f6a9";
+}
+.fa-hand-sparkles:before {
+  content: "\e05d";
+}
+.fa-grip-horizontal:before,
+.fa-grip:before {
+  content: "\f58d";
+}
+.fa-share-from-square:before,
+.fa-share-square:before {
+  content: "\f14d";
+}
+.fa-child-combatant:before,
+.fa-child-rifle:before {
+  content: "\e4e0";
+}
+.fa-gun:before {
+  content: "\e19b";
+}
+.fa-phone-square:before,
+.fa-square-phone:before {
+  content: "\f098";
+}
+.fa-add:before,
+.fa-plus:before {
+  content: "\2b";
+}
+.fa-expand:before {
+  content: "\f065";
+}
+.fa-computer:before {
+  content: "\e4e5";
+}
+.fa-close:before,
+.fa-multiply:before,
+.fa-remove:before,
+.fa-times:before,
+.fa-xmark:before {
+  content: "\f00d";
+}
+.fa-arrows-up-down-left-right:before,
+.fa-arrows:before {
+  content: "\f047";
+}
+.fa-chalkboard-teacher:before,
+.fa-chalkboard-user:before {
+  content: "\f51c";
+}
+.fa-peso-sign:before {
+  content: "\e222";
+}
+.fa-building-shield:before {
+  content: "\e4d8";
+}
+.fa-baby:before {
+  content: "\f77c";
+}
+.fa-users-line:before {
+  content: "\e592";
+}
+.fa-quote-left-alt:before,
+.fa-quote-left:before {
+  content: "\f10d";
+}
+.fa-tractor:before {
+  content: "\f722";
+}
+.fa-trash-arrow-up:before,
+.fa-trash-restore:before {
+  content: "\f829";
+}
+.fa-arrow-down-up-lock:before {
+  content: "\e4b0";
+}
+.fa-lines-leaning:before {
+  content: "\e51e";
+}
+.fa-ruler-combined:before {
+  content: "\f546";
+}
+.fa-copyright:before {
+  content: "\f1f9";
+}
+.fa-equals:before {
+  content: "\3d";
+}
+.fa-blender:before {
+  content: "\f517";
+}
+.fa-teeth:before {
+  content: "\f62e";
+}
+.fa-ils:before,
+.fa-shekel-sign:before,
+.fa-shekel:before,
+.fa-sheqel-sign:before,
+.fa-sheqel:before {
+  content: "\f20b";
+}
+.fa-map:before {
+  content: "\f279";
+}
+.fa-rocket:before {
+  content: "\f135";
+}
+.fa-photo-film:before,
+.fa-photo-video:before {
+  content: "\f87c";
+}
+.fa-folder-minus:before {
+  content: "\f65d";
+}
+.fa-store:before {
+  content: "\f54e";
+}
+.fa-arrow-trend-up:before {
+  content: "\e098";
+}
+.fa-plug-circle-minus:before {
+  content: "\e55e";
+}
+.fa-sign-hanging:before,
+.fa-sign:before {
+  content: "\f4d9";
+}
+.fa-bezier-curve:before {
+  content: "\f55b";
+}
+.fa-bell-slash:before {
+  content: "\f1f6";
+}
+.fa-tablet-android:before,
+.fa-tablet:before {
+  content: "\f3fb";
+}
+.fa-school-flag:before {
+  content: "\e56e";
+}
+.fa-fill:before {
+  content: "\f575";
+}
+.fa-angle-up:before {
+  content: "\f106";
+}
+.fa-drumstick-bite:before {
+  content: "\f6d7";
+}
+.fa-holly-berry:before {
+  content: "\f7aa";
+}
+.fa-chevron-left:before {
+  content: "\f053";
+}
+.fa-bacteria:before {
+  content: "\e059";
+}
+.fa-hand-lizard:before {
+  content: "\f258";
+}
+.fa-notdef:before {
+  content: "\e1fe";
+}
+.fa-disease:before {
+  content: "\f7fa";
+}
+.fa-briefcase-medical:before {
+  content: "\f469";
+}
+.fa-genderless:before {
+  content: "\f22d";
+}
+.fa-chevron-right:before {
+  content: "\f054";
+}
+.fa-retweet:before {
+  content: "\f079";
+}
+.fa-car-alt:before,
+.fa-car-rear:before {
+  content: "\f5de";
+}
+.fa-pump-soap:before {
+  content: "\e06b";
+}
+.fa-video-slash:before {
+  content: "\f4e2";
+}
+.fa-battery-2:before,
+.fa-battery-quarter:before {
+  content: "\f243";
+}
+.fa-radio:before {
+  content: "\f8d7";
+}
+.fa-baby-carriage:before,
+.fa-carriage-baby:before {
+  content: "\f77d";
+}
+.fa-traffic-light:before {
+  content: "\f637";
+}
+.fa-thermometer:before {
+  content: "\f491";
+}
+.fa-vr-cardboard:before {
+  content: "\f729";
+}
+.fa-hand-middle-finger:before {
+  content: "\f806";
+}
+.fa-percent:before,
+.fa-percentage:before {
+  content: "\25";
+}
+.fa-truck-moving:before {
+  content: "\f4df";
+}
+.fa-glass-water-droplet:before {
+  content: "\e4f5";
+}
+.fa-display:before {
+  content: "\e163";
+}
+.fa-face-smile:before,
+.fa-smile:before {
+  content: "\f118";
+}
+.fa-thumb-tack:before,
+.fa-thumbtack:before {
+  content: "\f08d";
+}
+.fa-trophy:before {
+  content: "\f091";
+}
+.fa-person-praying:before,
+.fa-pray:before {
+  content: "\f683";
+}
+.fa-hammer:before {
+  content: "\f6e3";
+}
+.fa-hand-peace:before {
+  content: "\f25b";
+}
+.fa-rotate:before,
+.fa-sync-alt:before {
+  content: "\f2f1";
+}
+.fa-spinner:before {
+  content: "\f110";
+}
+.fa-robot:before {
+  content: "\f544";
+}
+.fa-peace:before {
+  content: "\f67c";
+}
+.fa-cogs:before,
+.fa-gears:before {
+  content: "\f085";
+}
+.fa-warehouse:before {
+  content: "\f494";
+}
+.fa-arrow-up-right-dots:before {
+  content: "\e4b7";
+}
+.fa-splotch:before {
+  content: "\f5bc";
+}
+.fa-face-grin-hearts:before,
+.fa-grin-hearts:before {
+  content: "\f584";
+}
+.fa-dice-four:before {
+  content: "\f524";
+}
+.fa-sim-card:before {
+  content: "\f7c4";
+}
+.fa-transgender-alt:before,
+.fa-transgender:before {
+  content: "\f225";
+}
+.fa-mercury:before {
+  content: "\f223";
+}
+.fa-arrow-turn-down:before,
+.fa-level-down:before {
+  content: "\f149";
+}
+.fa-person-falling-burst:before {
+  content: "\e547";
+}
+.fa-award:before {
+  content: "\f559";
+}
+.fa-ticket-alt:before,
+.fa-ticket-simple:before {
+  content: "\f3ff";
+}
+.fa-building:before {
+  content: "\f1ad";
+}
+.fa-angle-double-left:before,
+.fa-angles-left:before {
+  content: "\f100";
+}
+.fa-qrcode:before {
+  content: "\f029";
+}
+.fa-clock-rotate-left:before,
+.fa-history:before {
+  content: "\f1da";
+}
+.fa-face-grin-beam-sweat:before,
+.fa-grin-beam-sweat:before {
+  content: "\f583";
+}
+.fa-arrow-right-from-file:before,
+.fa-file-export:before {
+  content: "\f56e";
+}
+.fa-shield-blank:before,
+.fa-shield:before {
+  content: "\f132";
+}
+.fa-arrow-up-short-wide:before,
+.fa-sort-amount-up-alt:before {
+  content: "\f885";
+}
+.fa-house-medical:before {
+  content: "\e3b2";
+}
+.fa-golf-ball-tee:before,
+.fa-golf-ball:before {
+  content: "\f450";
+}
+.fa-chevron-circle-left:before,
+.fa-circle-chevron-left:before {
+  content: "\f137";
+}
+.fa-house-chimney-window:before {
+  content: "\e00d";
+}
+.fa-pen-nib:before {
+  content: "\f5ad";
+}
+.fa-tent-arrow-turn-left:before {
+  content: "\e580";
+}
+.fa-tents:before {
+  content: "\e582";
+}
+.fa-magic:before,
+.fa-wand-magic:before {
+  content: "\f0d0";
+}
+.fa-dog:before {
+  content: "\f6d3";
+}
+.fa-carrot:before {
+  content: "\f787";
+}
+.fa-moon:before {
+  content: "\f186";
+}
+.fa-wine-glass-alt:before,
+.fa-wine-glass-empty:before {
+  content: "\f5ce";
+}
+.fa-cheese:before {
+  content: "\f7ef";
+}
+.fa-yin-yang:before {
+  content: "\f6ad";
+}
+.fa-music:before {
+  content: "\f001";
+}
+.fa-code-commit:before {
+  content: "\f386";
+}
+.fa-temperature-low:before {
+  content: "\f76b";
+}
+.fa-biking:before,
+.fa-person-biking:before {
+  content: "\f84a";
+}
+.fa-broom:before {
+  content: "\f51a";
+}
+.fa-shield-heart:before {
+  content: "\e574";
+}
+.fa-gopuram:before {
+  content: "\f664";
+}
+.fa-earth-oceania:before,
+.fa-globe-oceania:before {
+  content: "\e47b";
+}
+.fa-square-xmark:before,
+.fa-times-square:before,
+.fa-xmark-square:before {
+  content: "\f2d3";
+}
+.fa-hashtag:before {
+  content: "\23";
+}
+.fa-expand-alt:before,
+.fa-up-right-and-down-left-from-center:before {
+  content: "\f424";
+}
+.fa-oil-can:before {
+  content: "\f613";
+}
+.fa-t:before {
+  content: "\54";
+}
+.fa-hippo:before {
+  content: "\f6ed";
+}
+.fa-chart-column:before {
+  content: "\e0e3";
+}
+.fa-infinity:before {
+  content: "\f534";
+}
+.fa-vial-circle-check:before {
+  content: "\e596";
+}
+.fa-person-arrow-down-to-line:before {
+  content: "\e538";
+}
+.fa-voicemail:before {
+  content: "\f897";
+}
+.fa-fan:before {
+  content: "\f863";
+}
+.fa-person-walking-luggage:before {
+  content: "\e554";
+}
+.fa-arrows-alt-v:before,
+.fa-up-down:before {
+  content: "\f338";
+}
+.fa-cloud-moon-rain:before {
+  content: "\f73c";
+}
+.fa-calendar:before {
+  content: "\f133";
+}
+.fa-trailer:before {
+  content: "\e041";
+}
+.fa-bahai:before,
+.fa-haykal:before {
+  content: "\f666";
+}
+.fa-sd-card:before {
+  content: "\f7c2";
+}
+.fa-dragon:before {
+  content: "\f6d5";
+}
+.fa-shoe-prints:before {
+  content: "\f54b";
+}
+.fa-circle-plus:before,
+.fa-plus-circle:before {
+  content: "\f055";
+}
+.fa-face-grin-tongue-wink:before,
+.fa-grin-tongue-wink:before {
+  content: "\f58b";
+}
+.fa-hand-holding:before {
+  content: "\f4bd";
+}
+.fa-plug-circle-exclamation:before {
+  content: "\e55d";
+}
+.fa-chain-broken:before,
+.fa-chain-slash:before,
+.fa-link-slash:before,
+.fa-unlink:before {
+  content: "\f127";
+}
+.fa-clone:before {
+  content: "\f24d";
+}
+.fa-person-walking-arrow-loop-left:before {
+  content: "\e551";
+}
+.fa-arrow-up-z-a:before,
+.fa-sort-alpha-up-alt:before {
+  content: "\f882";
+}
+.fa-fire-alt:before,
+.fa-fire-flame-curved:before {
+  content: "\f7e4";
+}
+.fa-tornado:before {
+  content: "\f76f";
+}
+.fa-file-circle-plus:before {
+  content: "\e494";
+}
+.fa-book-quran:before,
+.fa-quran:before {
+  content: "\f687";
+}
+.fa-anchor:before {
+  content: "\f13d";
+}
+.fa-border-all:before {
+  content: "\f84c";
+}
+.fa-angry:before,
+.fa-face-angry:before {
+  content: "\f556";
+}
+.fa-cookie-bite:before {
+  content: "\f564";
+}
+.fa-arrow-trend-down:before {
+  content: "\e097";
+}
+.fa-feed:before,
+.fa-rss:before {
+  content: "\f09e";
+}
+.fa-draw-polygon:before {
+  content: "\f5ee";
+}
+.fa-balance-scale:before,
+.fa-scale-balanced:before {
+  content: "\f24e";
+}
+.fa-gauge-simple-high:before,
+.fa-tachometer-fast:before,
+.fa-tachometer:before {
+  content: "\f62a";
+}
+.fa-shower:before {
+  content: "\f2cc";
+}
+.fa-desktop-alt:before,
+.fa-desktop:before {
+  content: "\f390";
+}
+.fa-m:before {
+  content: "\4d";
+}
+.fa-table-list:before,
+.fa-th-list:before {
+  content: "\f00b";
+}
+.fa-comment-sms:before,
+.fa-sms:before {
+  content: "\f7cd";
+}
+.fa-book:before {
+  content: "\f02d";
+}
+.fa-user-plus:before {
+  content: "\f234";
+}
+.fa-check:before {
+  content: "\f00c";
+}
+.fa-battery-4:before,
+.fa-battery-three-quarters:before {
+  content: "\f241";
+}
+.fa-house-circle-check:before {
+  content: "\e509";
+}
+.fa-angle-left:before {
+  content: "\f104";
+}
+.fa-diagram-successor:before {
+  content: "\e47a";
+}
+.fa-truck-arrow-right:before {
+  content: "\e58b";
+}
+.fa-arrows-split-up-and-left:before {
+  content: "\e4bc";
+}
+.fa-fist-raised:before,
+.fa-hand-fist:before {
+  content: "\f6de";
+}
+.fa-cloud-moon:before {
+  content: "\f6c3";
+}
+.fa-briefcase:before {
+  content: "\f0b1";
+}
+.fa-person-falling:before {
+  content: "\e546";
+}
+.fa-image-portrait:before,
+.fa-portrait:before {
+  content: "\f3e0";
+}
+.fa-user-tag:before {
+  content: "\f507";
+}
+.fa-rug:before {
+  content: "\e569";
+}
+.fa-earth-europe:before,
+.fa-globe-europe:before {
+  content: "\f7a2";
+}
+.fa-cart-flatbed-suitcase:before,
+.fa-luggage-cart:before {
+  content: "\f59d";
+}
+.fa-rectangle-times:before,
+.fa-rectangle-xmark:before,
+.fa-times-rectangle:before,
+.fa-window-close:before {
+  content: "\f410";
+}
+.fa-baht-sign:before {
+  content: "\e0ac";
+}
+.fa-book-open:before {
+  content: "\f518";
+}
+.fa-book-journal-whills:before,
+.fa-journal-whills:before {
+  content: "\f66a";
+}
+.fa-handcuffs:before {
+  content: "\e4f8";
+}
+.fa-exclamation-triangle:before,
+.fa-triangle-exclamation:before,
+.fa-warning:before {
+  content: "\f071";
+}
+.fa-database:before {
+  content: "\f1c0";
+}
+.fa-arrow-turn-right:before,
+.fa-mail-forward:before,
+.fa-share:before {
+  content: "\f064";
+}
+.fa-bottle-droplet:before {
+  content: "\e4c4";
+}
+.fa-mask-face:before {
+  content: "\e1d7";
+}
+.fa-hill-rockslide:before {
+  content: "\e508";
+}
+.fa-exchange-alt:before,
+.fa-right-left:before {
+  content: "\f362";
+}
+.fa-paper-plane:before {
+  content: "\f1d8";
+}
+.fa-road-circle-exclamation:before {
+  content: "\e565";
+}
+.fa-dungeon:before {
+  content: "\f6d9";
+}
+.fa-align-right:before {
+  content: "\f038";
+}
+.fa-money-bill-1-wave:before,
+.fa-money-bill-wave-alt:before {
+  content: "\f53b";
+}
+.fa-life-ring:before {
+  content: "\f1cd";
+}
+.fa-hands:before,
+.fa-sign-language:before,
+.fa-signing:before {
+  content: "\f2a7";
+}
+.fa-calendar-day:before {
+  content: "\f783";
+}
+.fa-ladder-water:before,
+.fa-swimming-pool:before,
+.fa-water-ladder:before {
+  content: "\f5c5";
+}
+.fa-arrows-up-down:before,
+.fa-arrows-v:before {
+  content: "\f07d";
+}
+.fa-face-grimace:before,
+.fa-grimace:before {
+  content: "\f57f";
+}
+.fa-wheelchair-alt:before,
+.fa-wheelchair-move:before {
+  content: "\e2ce";
+}
+.fa-level-down-alt:before,
+.fa-turn-down:before {
+  content: "\f3be";
+}
+.fa-person-walking-arrow-right:before {
+  content: "\e552";
+}
+.fa-envelope-square:before,
+.fa-square-envelope:before {
+  content: "\f199";
+}
+.fa-dice:before {
+  content: "\f522";
+}
+.fa-bowling-ball:before {
+  content: "\f436";
+}
+.fa-brain:before {
+  content: "\f5dc";
+}
+.fa-band-aid:before,
+.fa-bandage:before {
+  content: "\f462";
+}
+.fa-calendar-minus:before {
+  content: "\f272";
+}
+.fa-circle-xmark:before,
+.fa-times-circle:before,
+.fa-xmark-circle:before {
+  content: "\f057";
+}
+.fa-gifts:before {
+  content: "\f79c";
+}
+.fa-hotel:before {
+  content: "\f594";
+}
+.fa-earth-asia:before,
+.fa-globe-asia:before {
+  content: "\f57e";
+}
+.fa-id-card-alt:before,
+.fa-id-card-clip:before {
+  content: "\f47f";
+}
+.fa-magnifying-glass-plus:before,
+.fa-search-plus:before {
+  content: "\f00e";
+}
+.fa-thumbs-up:before {
+  content: "\f164";
+}
+.fa-user-clock:before {
+  content: "\f4fd";
+}
+.fa-allergies:before,
+.fa-hand-dots:before {
+  content: "\f461";
+}
+.fa-file-invoice:before {
+  content: "\f570";
+}
+.fa-window-minimize:before {
+  content: "\f2d1";
+}
+.fa-coffee:before,
+.fa-mug-saucer:before {
+  content: "\f0f4";
+}
+.fa-brush:before {
+  content: "\f55d";
+}
+.fa-mask:before {
+  content: "\f6fa";
+}
+.fa-magnifying-glass-minus:before,
+.fa-search-minus:before {
+  content: "\f010";
+}
+.fa-ruler-vertical:before {
+  content: "\f548";
+}
+.fa-user-alt:before,
+.fa-user-large:before {
+  content: "\f406";
+}
+.fa-train-tram:before {
+  content: "\e5b4";
+}
+.fa-user-nurse:before {
+  content: "\f82f";
+}
+.fa-syringe:before {
+  content: "\f48e";
+}
+.fa-cloud-sun:before {
+  content: "\f6c4";
+}
+.fa-stopwatch-20:before {
+  content: "\e06f";
+}
+.fa-square-full:before {
+  content: "\f45c";
+}
+.fa-magnet:before {
+  content: "\f076";
+}
+.fa-jar:before {
+  content: "\e516";
+}
+.fa-note-sticky:before,
+.fa-sticky-note:before {
+  content: "\f249";
+}
+.fa-bug-slash:before {
+  content: "\e490";
+}
+.fa-arrow-up-from-water-pump:before {
+  content: "\e4b6";
+}
+.fa-bone:before {
+  content: "\f5d7";
+}
+.fa-user-injured:before {
+  content: "\f728";
+}
+.fa-face-sad-tear:before,
+.fa-sad-tear:before {
+  content: "\f5b4";
+}
+.fa-plane:before {
+  content: "\f072";
+}
+.fa-tent-arrows-down:before {
+  content: "\e581";
+}
+.fa-exclamation:before {
+  content: "\21";
+}
+.fa-arrows-spin:before {
+  content: "\e4bb";
+}
+.fa-print:before {
+  content: "\f02f";
+}
+.fa-try:before,
+.fa-turkish-lira-sign:before,
+.fa-turkish-lira:before {
+  content: "\e2bb";
+}
+.fa-dollar-sign:before,
+.fa-dollar:before,
+.fa-usd:before {
+  content: "\24";
+}
+.fa-x:before {
+  content: "\58";
+}
+.fa-magnifying-glass-dollar:before,
+.fa-search-dollar:before {
+  content: "\f688";
+}
+.fa-users-cog:before,
+.fa-users-gear:before {
+  content: "\f509";
+}
+.fa-person-military-pointing:before {
+  content: "\e54a";
+}
+.fa-bank:before,
+.fa-building-columns:before,
+.fa-institution:before,
+.fa-museum:before,
+.fa-university:before {
+  content: "\f19c";
+}
+.fa-umbrella:before {
+  content: "\f0e9";
+}
+.fa-trowel:before {
+  content: "\e589";
+}
+.fa-d:before {
+  content: "\44";
+}
+.fa-stapler:before {
+  content: "\e5af";
+}
+.fa-masks-theater:before,
+.fa-theater-masks:before {
+  content: "\f630";
+}
+.fa-kip-sign:before {
+  content: "\e1c4";
+}
+.fa-hand-point-left:before {
+  content: "\f0a5";
+}
+.fa-handshake-alt:before,
+.fa-handshake-simple:before {
+  content: "\f4c6";
+}
+.fa-fighter-jet:before,
+.fa-jet-fighter:before {
+  content: "\f0fb";
+}
+.fa-share-alt-square:before,
+.fa-square-share-nodes:before {
+  content: "\f1e1";
+}
+.fa-barcode:before {
+  content: "\f02a";
+}
+.fa-plus-minus:before {
+  content: "\e43c";
+}
+.fa-video-camera:before,
+.fa-video:before {
+  content: "\f03d";
+}
+.fa-graduation-cap:before,
+.fa-mortar-board:before {
+  content: "\f19d";
+}
+.fa-hand-holding-medical:before {
+  content: "\e05c";
+}
+.fa-person-circle-check:before {
+  content: "\e53e";
+}
+.fa-level-up-alt:before,
+.fa-turn-up:before {
+  content: "\f3bf";
+}
+.fa-sr-only,
+.fa-sr-only-focusable:not(:focus),
+.sr-only,
+.sr-only-focusable:not(:focus) {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+:host,
+:root {
+  --fa-style-family-brands: "Font Awesome 6 Brands";
+  --fa-font-brands: normal 400 1em/1 "Font Awesome 6 Brands";
+}
+@font-face {
+  font-family: "Font Awesome 6 Brands";
+  font-style: normal;
+  font-weight: 400;
+  font-display: block;
+  src:
+    url(../webfonts/fa-brands-400.woff2) format("woff2"),
+    url(../webfonts/fa-brands-400.ttf) format("truetype");
+}
+.fa-brands,
+.fab {
+  font-weight: 400;
+}
+.fa-monero:before {
+  content: "\f3d0";
+}
+.fa-hooli:before {
+  content: "\f427";
+}
+.fa-yelp:before {
+  content: "\f1e9";
+}
+.fa-cc-visa:before {
+  content: "\f1f0";
+}
+.fa-lastfm:before {
+  content: "\f202";
+}
+.fa-shopware:before {
+  content: "\f5b5";
+}
+.fa-creative-commons-nc:before {
+  content: "\f4e8";
+}
+.fa-aws:before {
+  content: "\f375";
+}
+.fa-redhat:before {
+  content: "\f7bc";
+}
+.fa-yoast:before {
+  content: "\f2b1";
+}
+.fa-cloudflare:before {
+  content: "\e07d";
+}
+.fa-ups:before {
+  content: "\f7e0";
+}
+.fa-wpexplorer:before {
+  content: "\f2de";
+}
+.fa-dyalog:before {
+  content: "\f399";
+}
+.fa-bity:before {
+  content: "\f37a";
+}
+.fa-stackpath:before {
+  content: "\f842";
+}
+.fa-buysellads:before {
+  content: "\f20d";
+}
+.fa-first-order:before {
+  content: "\f2b0";
+}
+.fa-modx:before {
+  content: "\f285";
+}
+.fa-guilded:before {
+  content: "\e07e";
+}
+.fa-vnv:before {
+  content: "\f40b";
+}
+.fa-js-square:before,
+.fa-square-js:before {
+  content: "\f3b9";
+}
+.fa-microsoft:before {
+  content: "\f3ca";
+}
+.fa-qq:before {
+  content: "\f1d6";
+}
+.fa-orcid:before {
+  content: "\f8d2";
+}
+.fa-java:before {
+  content: "\f4e4";
+}
+.fa-invision:before {
+  content: "\f7b0";
+}
+.fa-creative-commons-pd-alt:before {
+  content: "\f4ed";
+}
+.fa-centercode:before {
+  content: "\f380";
+}
+.fa-glide-g:before {
+  content: "\f2a6";
+}
+.fa-drupal:before {
+  content: "\f1a9";
+}
+.fa-hire-a-helper:before {
+  content: "\f3b0";
+}
+.fa-creative-commons-by:before {
+  content: "\f4e7";
+}
+.fa-unity:before {
+  content: "\e049";
+}
+.fa-whmcs:before {
+  content: "\f40d";
+}
+.fa-rocketchat:before {
+  content: "\f3e8";
+}
+.fa-vk:before {
+  content: "\f189";
+}
+.fa-untappd:before {
+  content: "\f405";
+}
+.fa-mailchimp:before {
+  content: "\f59e";
+}
+.fa-css3-alt:before {
+  content: "\f38b";
+}
+.fa-reddit-square:before,
+.fa-square-reddit:before {
+  content: "\f1a2";
+}
+.fa-vimeo-v:before {
+  content: "\f27d";
+}
+.fa-contao:before {
+  content: "\f26d";
+}
+.fa-square-font-awesome:before {
+  content: "\e5ad";
+}
+.fa-deskpro:before {
+  content: "\f38f";
+}
+.fa-sistrix:before {
+  content: "\f3ee";
+}
+.fa-instagram-square:before,
+.fa-square-instagram:before {
+  content: "\e055";
+}
+.fa-battle-net:before {
+  content: "\f835";
+}
+.fa-the-red-yeti:before {
+  content: "\f69d";
+}
+.fa-hacker-news-square:before,
+.fa-square-hacker-news:before {
+  content: "\f3af";
+}
+.fa-edge:before {
+  content: "\f282";
+}
+.fa-napster:before {
+  content: "\f3d2";
+}
+.fa-snapchat-square:before,
+.fa-square-snapchat:before {
+  content: "\f2ad";
+}
+.fa-google-plus-g:before {
+  content: "\f0d5";
+}
+.fa-artstation:before {
+  content: "\f77a";
+}
+.fa-markdown:before {
+  content: "\f60f";
+}
+.fa-sourcetree:before {
+  content: "\f7d3";
+}
+.fa-google-plus:before {
+  content: "\f2b3";
+}
+.fa-diaspora:before {
+  content: "\f791";
+}
+.fa-foursquare:before {
+  content: "\f180";
+}
+.fa-stack-overflow:before {
+  content: "\f16c";
+}
+.fa-github-alt:before {
+  content: "\f113";
+}
+.fa-phoenix-squadron:before {
+  content: "\f511";
+}
+.fa-pagelines:before {
+  content: "\f18c";
+}
+.fa-algolia:before {
+  content: "\f36c";
+}
+.fa-red-river:before {
+  content: "\f3e3";
+}
+.fa-creative-commons-sa:before {
+  content: "\f4ef";
+}
+.fa-safari:before {
+  content: "\f267";
+}
+.fa-google:before {
+  content: "\f1a0";
+}
+.fa-font-awesome-alt:before,
+.fa-square-font-awesome-stroke:before {
+  content: "\f35c";
+}
+.fa-atlassian:before {
+  content: "\f77b";
+}
+.fa-linkedin-in:before {
+  content: "\f0e1";
+}
+.fa-digital-ocean:before {
+  content: "\f391";
+}
+.fa-nimblr:before {
+  content: "\f5a8";
+}
+.fa-chromecast:before {
+  content: "\f838";
+}
+.fa-evernote:before {
+  content: "\f839";
+}
+.fa-hacker-news:before {
+  content: "\f1d4";
+}
+.fa-creative-commons-sampling:before {
+  content: "\f4f0";
+}
+.fa-adversal:before {
+  content: "\f36a";
+}
+.fa-creative-commons:before {
+  content: "\f25e";
+}
+.fa-watchman-monitoring:before {
+  content: "\e087";
+}
+.fa-fonticons:before {
+  content: "\f280";
+}
+.fa-weixin:before {
+  content: "\f1d7";
+}
+.fa-shirtsinbulk:before {
+  content: "\f214";
+}
+.fa-codepen:before {
+  content: "\f1cb";
+}
+.fa-git-alt:before {
+  content: "\f841";
+}
+.fa-lyft:before {
+  content: "\f3c3";
+}
+.fa-rev:before {
+  content: "\f5b2";
+}
+.fa-windows:before {
+  content: "\f17a";
+}
+.fa-wizards-of-the-coast:before {
+  content: "\f730";
+}
+.fa-square-viadeo:before,
+.fa-viadeo-square:before {
+  content: "\f2aa";
+}
+.fa-meetup:before {
+  content: "\f2e0";
+}
+.fa-centos:before {
+  content: "\f789";
+}
+.fa-adn:before {
+  content: "\f170";
+}
+.fa-cloudsmith:before {
+  content: "\f384";
+}
+.fa-pied-piper-alt:before {
+  content: "\f1a8";
+}
+.fa-dribbble-square:before,
+.fa-square-dribbble:before {
+  content: "\f397";
+}
+.fa-codiepie:before {
+  content: "\f284";
+}
+.fa-node:before {
+  content: "\f419";
+}
+.fa-mix:before {
+  content: "\f3cb";
+}
+.fa-steam:before {
+  content: "\f1b6";
+}
+.fa-cc-apple-pay:before {
+  content: "\f416";
+}
+.fa-scribd:before {
+  content: "\f28a";
+}
+.fa-openid:before {
+  content: "\f19b";
+}
+.fa-instalod:before {
+  content: "\e081";
+}
+.fa-expeditedssl:before {
+  content: "\f23e";
+}
+.fa-sellcast:before {
+  content: "\f2da";
+}
+.fa-square-twitter:before,
+.fa-twitter-square:before {
+  content: "\f081";
+}
+.fa-r-project:before {
+  content: "\f4f7";
+}
+.fa-delicious:before {
+  content: "\f1a5";
+}
+.fa-freebsd:before {
+  content: "\f3a4";
+}
+.fa-vuejs:before {
+  content: "\f41f";
+}
+.fa-accusoft:before {
+  content: "\f369";
+}
+.fa-ioxhost:before {
+  content: "\f208";
+}
+.fa-fonticons-fi:before {
+  content: "\f3a2";
+}
+.fa-app-store:before {
+  content: "\f36f";
+}
+.fa-cc-mastercard:before {
+  content: "\f1f1";
+}
+.fa-itunes-note:before {
+  content: "\f3b5";
+}
+.fa-golang:before {
+  content: "\e40f";
+}
+.fa-kickstarter:before {
+  content: "\f3bb";
+}
+.fa-grav:before {
+  content: "\f2d6";
+}
+.fa-weibo:before {
+  content: "\f18a";
+}
+.fa-uncharted:before {
+  content: "\e084";
+}
+.fa-firstdraft:before {
+  content: "\f3a1";
+}
+.fa-square-youtube:before,
+.fa-youtube-square:before {
+  content: "\f431";
+}
+.fa-wikipedia-w:before {
+  content: "\f266";
+}
+.fa-rendact:before,
+.fa-wpressr:before {
+  content: "\f3e4";
+}
+.fa-angellist:before {
+  content: "\f209";
+}
+.fa-galactic-republic:before {
+  content: "\f50c";
+}
+.fa-nfc-directional:before {
+  content: "\e530";
+}
+.fa-skype:before {
+  content: "\f17e";
+}
+.fa-joget:before {
+  content: "\f3b7";
+}
+.fa-fedora:before {
+  content: "\f798";
+}
+.fa-stripe-s:before {
+  content: "\f42a";
+}
+.fa-meta:before {
+  content: "\e49b";
+}
+.fa-laravel:before {
+  content: "\f3bd";
+}
+.fa-hotjar:before {
+  content: "\f3b1";
+}
+.fa-bluetooth-b:before {
+  content: "\f294";
+}
+.fa-sticker-mule:before {
+  content: "\f3f7";
+}
+.fa-creative-commons-zero:before {
+  content: "\f4f3";
+}
+.fa-hips:before {
+  content: "\f452";
+}
+.fa-behance:before {
+  content: "\f1b4";
+}
+.fa-reddit:before {
+  content: "\f1a1";
+}
+.fa-discord:before {
+  content: "\f392";
+}
+.fa-chrome:before {
+  content: "\f268";
+}
+.fa-app-store-ios:before {
+  content: "\f370";
+}
+.fa-cc-discover:before {
+  content: "\f1f2";
+}
+.fa-wpbeginner:before {
+  content: "\f297";
+}
+.fa-confluence:before {
+  content: "\f78d";
+}
+.fa-mdb:before {
+  content: "\f8ca";
+}
+.fa-dochub:before {
+  content: "\f394";
+}
+.fa-accessible-icon:before {
+  content: "\f368";
+}
+.fa-ebay:before {
+  content: "\f4f4";
+}
+.fa-amazon:before {
+  content: "\f270";
+}
+.fa-unsplash:before {
+  content: "\e07c";
+}
+.fa-yarn:before {
+  content: "\f7e3";
+}
+.fa-square-steam:before,
+.fa-steam-square:before {
+  content: "\f1b7";
+}
+.fa-500px:before {
+  content: "\f26e";
+}
+.fa-square-vimeo:before,
+.fa-vimeo-square:before {
+  content: "\f194";
+}
+.fa-asymmetrik:before {
+  content: "\f372";
+}
+.fa-font-awesome-flag:before,
+.fa-font-awesome-logo-full:before,
+.fa-font-awesome:before {
+  content: "\f2b4";
+}
+.fa-gratipay:before {
+  content: "\f184";
+}
+.fa-apple:before {
+  content: "\f179";
+}
+.fa-hive:before {
+  content: "\e07f";
+}
+.fa-gitkraken:before {
+  content: "\f3a6";
+}
+.fa-keybase:before {
+  content: "\f4f5";
+}
+.fa-apple-pay:before {
+  content: "\f415";
+}
+.fa-padlet:before {
+  content: "\e4a0";
+}
+.fa-amazon-pay:before {
+  content: "\f42c";
+}
+.fa-github-square:before,
+.fa-square-github:before {
+  content: "\f092";
+}
+.fa-stumbleupon:before {
+  content: "\f1a4";
+}
+.fa-fedex:before {
+  content: "\f797";
+}
+.fa-phoenix-framework:before {
+  content: "\f3dc";
+}
+.fa-shopify:before {
+  content: "\e057";
+}
+.fa-neos:before {
+  content: "\f612";
+}
+.fa-hackerrank:before {
+  content: "\f5f7";
+}
+.fa-researchgate:before {
+  content: "\f4f8";
+}
+.fa-swift:before {
+  content: "\f8e1";
+}
+.fa-angular:before {
+  content: "\f420";
+}
+.fa-speakap:before {
+  content: "\f3f3";
+}
+.fa-angrycreative:before {
+  content: "\f36e";
+}
+.fa-y-combinator:before {
+  content: "\f23b";
+}
+.fa-empire:before {
+  content: "\f1d1";
+}
+.fa-envira:before {
+  content: "\f299";
+}
+.fa-gitlab-square:before,
+.fa-square-gitlab:before {
+  content: "\e5ae";
+}
+.fa-studiovinari:before {
+  content: "\f3f8";
+}
+.fa-pied-piper:before {
+  content: "\f2ae";
+}
+.fa-wordpress:before {
+  content: "\f19a";
+}
+.fa-product-hunt:before {
+  content: "\f288";
+}
+.fa-firefox:before {
+  content: "\f269";
+}
+.fa-linode:before {
+  content: "\f2b8";
+}
+.fa-goodreads:before {
+  content: "\f3a8";
+}
+.fa-odnoklassniki-square:before,
+.fa-square-odnoklassniki:before {
+  content: "\f264";
+}
+.fa-jsfiddle:before {
+  content: "\f1cc";
+}
+.fa-sith:before {
+  content: "\f512";
+}
+.fa-themeisle:before {
+  content: "\f2b2";
+}
+.fa-page4:before {
+  content: "\f3d7";
+}
+.fa-hashnode:before {
+  content: "\e499";
+}
+.fa-react:before {
+  content: "\f41b";
+}
+.fa-cc-paypal:before {
+  content: "\f1f4";
+}
+.fa-squarespace:before {
+  content: "\f5be";
+}
+.fa-cc-stripe:before {
+  content: "\f1f5";
+}
+.fa-creative-commons-share:before {
+  content: "\f4f2";
+}
+.fa-bitcoin:before {
+  content: "\f379";
+}
+.fa-keycdn:before {
+  content: "\f3ba";
+}
+.fa-opera:before {
+  content: "\f26a";
+}
+.fa-itch-io:before {
+  content: "\f83a";
+}
+.fa-umbraco:before {
+  content: "\f8e8";
+}
+.fa-galactic-senate:before {
+  content: "\f50d";
+}
+.fa-ubuntu:before {
+  content: "\f7df";
+}
+.fa-draft2digital:before {
+  content: "\f396";
+}
+.fa-stripe:before {
+  content: "\f429";
+}
+.fa-houzz:before {
+  content: "\f27c";
+}
+.fa-gg:before {
+  content: "\f260";
+}
+.fa-dhl:before {
+  content: "\f790";
+}
+.fa-pinterest-square:before,
+.fa-square-pinterest:before {
+  content: "\f0d3";
+}
+.fa-xing:before {
+  content: "\f168";
+}
+.fa-blackberry:before {
+  content: "\f37b";
+}
+.fa-creative-commons-pd:before {
+  content: "\f4ec";
+}
+.fa-playstation:before {
+  content: "\f3df";
+}
+.fa-quinscape:before {
+  content: "\f459";
+}
+.fa-less:before {
+  content: "\f41d";
+}
+.fa-blogger-b:before {
+  content: "\f37d";
+}
+.fa-opencart:before {
+  content: "\f23d";
+}
+.fa-vine:before {
+  content: "\f1ca";
+}
+.fa-paypal:before {
+  content: "\f1ed";
+}
+.fa-gitlab:before {
+  content: "\f296";
+}
+.fa-typo3:before {
+  content: "\f42b";
+}
+.fa-reddit-alien:before {
+  content: "\f281";
+}
+.fa-yahoo:before {
+  content: "\f19e";
+}
+.fa-dailymotion:before {
+  content: "\e052";
+}
+.fa-affiliatetheme:before {
+  content: "\f36b";
+}
+.fa-pied-piper-pp:before {
+  content: "\f1a7";
+}
+.fa-bootstrap:before {
+  content: "\f836";
+}
+.fa-odnoklassniki:before {
+  content: "\f263";
+}
+.fa-nfc-symbol:before {
+  content: "\e531";
+}
+.fa-ethereum:before {
+  content: "\f42e";
+}
+.fa-speaker-deck:before {
+  content: "\f83c";
+}
+.fa-creative-commons-nc-eu:before {
+  content: "\f4e9";
+}
+.fa-patreon:before {
+  content: "\f3d9";
+}
+.fa-avianex:before {
+  content: "\f374";
+}
+.fa-ello:before {
+  content: "\f5f1";
+}
+.fa-gofore:before {
+  content: "\f3a7";
+}
+.fa-bimobject:before {
+  content: "\f378";
+}
+.fa-facebook-f:before {
+  content: "\f39e";
+}
+.fa-google-plus-square:before,
+.fa-square-google-plus:before {
+  content: "\f0d4";
+}
+.fa-mandalorian:before {
+  content: "\f50f";
+}
+.fa-first-order-alt:before {
+  content: "\f50a";
+}
+.fa-osi:before {
+  content: "\f41a";
+}
+.fa-google-wallet:before {
+  content: "\f1ee";
+}
+.fa-d-and-d-beyond:before {
+  content: "\f6ca";
+}
+.fa-periscope:before {
+  content: "\f3da";
+}
+.fa-fulcrum:before {
+  content: "\f50b";
+}
+.fa-cloudscale:before {
+  content: "\f383";
+}
+.fa-forumbee:before {
+  content: "\f211";
+}
+.fa-mizuni:before {
+  content: "\f3cc";
+}
+.fa-schlix:before {
+  content: "\f3ea";
+}
+.fa-square-xing:before,
+.fa-xing-square:before {
+  content: "\f169";
+}
+.fa-bandcamp:before {
+  content: "\f2d5";
+}
+.fa-wpforms:before {
+  content: "\f298";
+}
+.fa-cloudversify:before {
+  content: "\f385";
+}
+.fa-usps:before {
+  content: "\f7e1";
+}
+.fa-megaport:before {
+  content: "\f5a3";
+}
+.fa-magento:before {
+  content: "\f3c4";
+}
+.fa-spotify:before {
+  content: "\f1bc";
+}
+.fa-optin-monster:before {
+  content: "\f23c";
+}
+.fa-fly:before {
+  content: "\f417";
+}
+.fa-aviato:before {
+  content: "\f421";
+}
+.fa-itunes:before {
+  content: "\f3b4";
+}
+.fa-cuttlefish:before {
+  content: "\f38c";
+}
+.fa-blogger:before {
+  content: "\f37c";
+}
+.fa-flickr:before {
+  content: "\f16e";
+}
+.fa-viber:before {
+  content: "\f409";
+}
+.fa-soundcloud:before {
+  content: "\f1be";
+}
+.fa-digg:before {
+  content: "\f1a6";
+}
+.fa-tencent-weibo:before {
+  content: "\f1d5";
+}
+.fa-symfony:before {
+  content: "\f83d";
+}
+.fa-maxcdn:before {
+  content: "\f136";
+}
+.fa-etsy:before {
+  content: "\f2d7";
+}
+.fa-facebook-messenger:before {
+  content: "\f39f";
+}
+.fa-audible:before {
+  content: "\f373";
+}
+.fa-think-peaks:before {
+  content: "\f731";
+}
+.fa-bilibili:before {
+  content: "\e3d9";
+}
+.fa-erlang:before {
+  content: "\f39d";
+}
+.fa-cotton-bureau:before {
+  content: "\f89e";
+}
+.fa-dashcube:before {
+  content: "\f210";
+}
+.fa-42-group:before,
+.fa-innosoft:before {
+  content: "\e080";
+}
+.fa-stack-exchange:before {
+  content: "\f18d";
+}
+.fa-elementor:before {
+  content: "\f430";
+}
+.fa-pied-piper-square:before,
+.fa-square-pied-piper:before {
+  content: "\e01e";
+}
+.fa-creative-commons-nd:before {
+  content: "\f4eb";
+}
+.fa-palfed:before {
+  content: "\f3d8";
+}
+.fa-superpowers:before {
+  content: "\f2dd";
+}
+.fa-resolving:before {
+  content: "\f3e7";
+}
+.fa-xbox:before {
+  content: "\f412";
+}
+.fa-searchengin:before {
+  content: "\f3eb";
+}
+.fa-tiktok:before {
+  content: "\e07b";
+}
+.fa-facebook-square:before,
+.fa-square-facebook:before {
+  content: "\f082";
+}
+.fa-renren:before {
+  content: "\f18b";
+}
+.fa-linux:before {
+  content: "\f17c";
+}
+.fa-glide:before {
+  content: "\f2a5";
+}
+.fa-linkedin:before {
+  content: "\f08c";
+}
+.fa-hubspot:before {
+  content: "\f3b2";
+}
+.fa-deploydog:before {
+  content: "\f38e";
+}
+.fa-twitch:before {
+  content: "\f1e8";
+}
+.fa-ravelry:before {
+  content: "\f2d9";
+}
+.fa-mixer:before {
+  content: "\e056";
+}
+.fa-lastfm-square:before,
+.fa-square-lastfm:before {
+  content: "\f203";
+}
+.fa-vimeo:before {
+  content: "\f40a";
+}
+.fa-mendeley:before {
+  content: "\f7b3";
+}
+.fa-uniregistry:before {
+  content: "\f404";
+}
+.fa-figma:before {
+  content: "\f799";
+}
+.fa-creative-commons-remix:before {
+  content: "\f4ee";
+}
+.fa-cc-amazon-pay:before {
+  content: "\f42d";
+}
+.fa-dropbox:before {
+  content: "\f16b";
+}
+.fa-instagram:before {
+  content: "\f16d";
+}
+.fa-cmplid:before {
+  content: "\e360";
+}
+.fa-facebook:before {
+  content: "\f09a";
+}
+.fa-gripfire:before {
+  content: "\f3ac";
+}
+.fa-jedi-order:before {
+  content: "\f50e";
+}
+.fa-uikit:before {
+  content: "\f403";
+}
+.fa-fort-awesome-alt:before {
+  content: "\f3a3";
+}
+.fa-phabricator:before {
+  content: "\f3db";
+}
+.fa-ussunnah:before {
+  content: "\f407";
+}
+.fa-earlybirds:before {
+  content: "\f39a";
+}
+.fa-trade-federation:before {
+  content: "\f513";
+}
+.fa-autoprefixer:before {
+  content: "\f41c";
+}
+.fa-whatsapp:before {
+  content: "\f232";
+}
+.fa-slideshare:before {
+  content: "\f1e7";
+}
+.fa-google-play:before {
+  content: "\f3ab";
+}
+.fa-viadeo:before {
+  content: "\f2a9";
+}
+.fa-line:before {
+  content: "\f3c0";
+}
+.fa-google-drive:before {
+  content: "\f3aa";
+}
+.fa-servicestack:before {
+  content: "\f3ec";
+}
+.fa-simplybuilt:before {
+  content: "\f215";
+}
+.fa-bitbucket:before {
+  content: "\f171";
+}
+.fa-imdb:before {
+  content: "\f2d8";
+}
+.fa-deezer:before {
+  content: "\e077";
+}
+.fa-raspberry-pi:before {
+  content: "\f7bb";
+}
+.fa-jira:before {
+  content: "\f7b1";
+}
+.fa-docker:before {
+  content: "\f395";
+}
+.fa-screenpal:before {
+  content: "\e570";
+}
+.fa-bluetooth:before {
+  content: "\f293";
+}
+.fa-gitter:before {
+  content: "\f426";
+}
+.fa-d-and-d:before {
+  content: "\f38d";
+}
+.fa-microblog:before {
+  content: "\e01a";
+}
+.fa-cc-diners-club:before {
+  content: "\f24c";
+}
+.fa-gg-circle:before {
+  content: "\f261";
+}
+.fa-pied-piper-hat:before {
+  content: "\f4e5";
+}
+.fa-kickstarter-k:before {
+  content: "\f3bc";
+}
+.fa-yandex:before {
+  content: "\f413";
+}
+.fa-readme:before {
+  content: "\f4d5";
+}
+.fa-html5:before {
+  content: "\f13b";
+}
+.fa-sellsy:before {
+  content: "\f213";
+}
+.fa-sass:before {
+  content: "\f41e";
+}
+.fa-wirsindhandwerk:before,
+.fa-wsh:before {
+  content: "\e2d0";
+}
+.fa-buromobelexperte:before {
+  content: "\f37f";
+}
+.fa-salesforce:before {
+  content: "\f83b";
+}
+.fa-octopus-deploy:before {
+  content: "\e082";
+}
+.fa-medapps:before {
+  content: "\f3c6";
+}
+.fa-ns8:before {
+  content: "\f3d5";
+}
+.fa-pinterest-p:before {
+  content: "\f231";
+}
+.fa-apper:before {
+  content: "\f371";
+}
+.fa-fort-awesome:before {
+  content: "\f286";
+}
+.fa-waze:before {
+  content: "\f83f";
+}
+.fa-cc-jcb:before {
+  content: "\f24b";
+}
+.fa-snapchat-ghost:before,
+.fa-snapchat:before {
+  content: "\f2ab";
+}
+.fa-fantasy-flight-games:before {
+  content: "\f6dc";
+}
+.fa-rust:before {
+  content: "\e07a";
+}
+.fa-wix:before {
+  content: "\f5cf";
+}
+.fa-behance-square:before,
+.fa-square-behance:before {
+  content: "\f1b5";
+}
+.fa-supple:before {
+  content: "\f3f9";
+}
+.fa-rebel:before {
+  content: "\f1d0";
+}
+.fa-css3:before {
+  content: "\f13c";
+}
+.fa-staylinked:before {
+  content: "\f3f5";
+}
+.fa-kaggle:before {
+  content: "\f5fa";
+}
+.fa-space-awesome:before {
+  content: "\e5ac";
+}
+.fa-deviantart:before {
+  content: "\f1bd";
+}
+.fa-cpanel:before {
+  content: "\f388";
+}
+.fa-goodreads-g:before {
+  content: "\f3a9";
+}
+.fa-git-square:before,
+.fa-square-git:before {
+  content: "\f1d2";
+}
+.fa-square-tumblr:before,
+.fa-tumblr-square:before {
+  content: "\f174";
+}
+.fa-trello:before {
+  content: "\f181";
+}
+.fa-creative-commons-nc-jp:before {
+  content: "\f4ea";
+}
+.fa-get-pocket:before {
+  content: "\f265";
+}
+.fa-perbyte:before {
+  content: "\e083";
+}
+.fa-grunt:before {
+  content: "\f3ad";
+}
+.fa-weebly:before {
+  content: "\f5cc";
+}
+.fa-connectdevelop:before {
+  content: "\f20e";
+}
+.fa-leanpub:before {
+  content: "\f212";
+}
+.fa-black-tie:before {
+  content: "\f27e";
+}
+.fa-themeco:before {
+  content: "\f5c6";
+}
+.fa-python:before {
+  content: "\f3e2";
+}
+.fa-android:before {
+  content: "\f17b";
+}
+.fa-bots:before {
+  content: "\e340";
+}
+.fa-free-code-camp:before {
+  content: "\f2c5";
+}
+.fa-hornbill:before {
+  content: "\f592";
+}
+.fa-js:before {
+  content: "\f3b8";
+}
+.fa-ideal:before {
+  content: "\e013";
+}
+.fa-git:before {
+  content: "\f1d3";
+}
+.fa-dev:before {
+  content: "\f6cc";
+}
+.fa-sketch:before {
+  content: "\f7c6";
+}
+.fa-yandex-international:before {
+  content: "\f414";
+}
+.fa-cc-amex:before {
+  content: "\f1f3";
+}
+.fa-uber:before {
+  content: "\f402";
+}
+.fa-github:before {
+  content: "\f09b";
+}
+.fa-php:before {
+  content: "\f457";
+}
+.fa-alipay:before {
+  content: "\f642";
+}
+.fa-youtube:before {
+  content: "\f167";
+}
+.fa-skyatlas:before {
+  content: "\f216";
+}
+.fa-firefox-browser:before {
+  content: "\e007";
+}
+.fa-replyd:before {
+  content: "\f3e6";
+}
+.fa-suse:before {
+  content: "\f7d6";
+}
+.fa-jenkins:before {
+  content: "\f3b6";
+}
+.fa-twitter:before {
+  content: "\f099";
+}
+.fa-rockrms:before {
+  content: "\f3e9";
+}
+.fa-pinterest:before {
+  content: "\f0d2";
+}
+.fa-buffer:before {
+  content: "\f837";
+}
+.fa-npm:before {
+  content: "\f3d4";
+}
+.fa-yammer:before {
+  content: "\f840";
+}
+.fa-btc:before {
+  content: "\f15a";
+}
+.fa-dribbble:before {
+  content: "\f17d";
+}
+.fa-stumbleupon-circle:before {
+  content: "\f1a3";
+}
+.fa-internet-explorer:before {
+  content: "\f26b";
+}
+.fa-stubber:before {
+  content: "\e5c7";
+}
+.fa-telegram-plane:before,
+.fa-telegram:before {
+  content: "\f2c6";
+}
+.fa-old-republic:before {
+  content: "\f510";
+}
+.fa-odysee:before {
+  content: "\e5c6";
+}
+.fa-square-whatsapp:before,
+.fa-whatsapp-square:before {
+  content: "\f40c";
+}
+.fa-node-js:before {
+  content: "\f3d3";
+}
+.fa-edge-legacy:before {
+  content: "\e078";
+}
+.fa-slack-hash:before,
+.fa-slack:before {
+  content: "\f198";
+}
+.fa-medrt:before {
+  content: "\f3c8";
+}
+.fa-usb:before {
+  content: "\f287";
+}
+.fa-tumblr:before {
+  content: "\f173";
+}
+.fa-vaadin:before {
+  content: "\f408";
+}
+.fa-quora:before {
+  content: "\f2c4";
+}
+.fa-reacteurope:before {
+  content: "\f75d";
+}
+.fa-medium-m:before,
+.fa-medium:before {
+  content: "\f23a";
+}
+.fa-amilia:before {
+  content: "\f36d";
+}
+.fa-mixcloud:before {
+  content: "\f289";
+}
+.fa-flipboard:before {
+  content: "\f44d";
+}
+.fa-viacoin:before {
+  content: "\f237";
+}
+.fa-critical-role:before {
+  content: "\f6c9";
+}
+.fa-sitrox:before {
+  content: "\e44a";
+}
+.fa-discourse:before {
+  content: "\f393";
+}
+.fa-joomla:before {
+  content: "\f1aa";
+}
+.fa-mastodon:before {
+  content: "\f4f6";
+}
+.fa-airbnb:before {
+  content: "\f834";
+}
+.fa-wolf-pack-battalion:before {
+  content: "\f514";
+}
+.fa-buy-n-large:before {
+  content: "\f8a6";
+}
+.fa-gulp:before {
+  content: "\f3ae";
+}
+.fa-creative-commons-sampling-plus:before {
+  content: "\f4f1";
+}
+.fa-strava:before {
+  content: "\f428";
+}
+.fa-ember:before {
+  content: "\f423";
+}
+.fa-canadian-maple-leaf:before {
+  content: "\f785";
+}
+.fa-teamspeak:before {
+  content: "\f4f9";
+}
+.fa-pushed:before {
+  content: "\f3e1";
+}
+.fa-wordpress-simple:before {
+  content: "\f411";
+}
+.fa-nutritionix:before {
+  content: "\f3d6";
+}
+.fa-wodu:before {
+  content: "\e088";
+}
+.fa-google-pay:before {
+  content: "\e079";
+}
+.fa-intercom:before {
+  content: "\f7af";
+}
+.fa-zhihu:before {
+  content: "\f63f";
+}
+.fa-korvue:before {
+  content: "\f42f";
+}
+.fa-pix:before {
+  content: "\e43a";
+}
+.fa-steam-symbol:before {
+  content: "\f3f6";
+}
+:host,
+:root {
+  --fa-font-regular: normal 400 1em/1 "Font Awesome 6 Free";
+}
+@font-face {
+  font-family: "Font Awesome 6 Free";
+  font-style: normal;
+  font-weight: 400;
+  font-display: block;
+  src:
+    url(../webfonts/fa-regular-400.woff2) format("woff2"),
+    url(../webfonts/fa-regular-400.ttf) format("truetype");
+}
+.fa-regular,
+.far {
+  font-weight: 400;
+}
+:host,
+:root {
+  --fa-style-family-classic: "Font Awesome 6 Free";
+  --fa-font-solid: normal 900 1em/1 "Font Awesome 6 Free";
+}
+@font-face {
+  font-family: "Font Awesome 6 Free";
+  font-style: normal;
+  font-weight: 900;
+  font-display: block;
+  src:
+    url(../webfonts/fa-solid-900.woff2) format("woff2"),
+    url(../webfonts/fa-solid-900.ttf) format("truetype");
+}
+.fa-solid,
+.fas {
+  font-weight: 900;
+}
+@font-face {
+  font-family: "Font Awesome 5 Brands";
+  font-display: block;
+  font-weight: 400;
+  src:
+    url(../webfonts/fa-brands-400.woff2) format("woff2"),
+    url(../webfonts/fa-brands-400.ttf) format("truetype");
+}
+@font-face {
+  font-family: "Font Awesome 5 Free";
+  font-display: block;
+  font-weight: 900;
+  src:
+    url(../webfonts/fa-solid-900.woff2) format("woff2"),
+    url(../webfonts/fa-solid-900.ttf) format("truetype");
+}
+@font-face {
+  font-family: "Font Awesome 5 Free";
+  font-display: block;
+  font-weight: 400;
+  src:
+    url(../webfonts/fa-regular-400.woff2) format("woff2"),
+    url(../webfonts/fa-regular-400.ttf) format("truetype");
+}
+@font-face {
+  font-family: "FontAwesome";
+  font-display: block;
+  src:
+    url(../webfonts/fa-solid-900.woff2) format("woff2"),
+    url(../webfonts/fa-solid-900.ttf) format("truetype");
+}
+@font-face {
+  font-family: "FontAwesome";
+  font-display: block;
+  src:
+    url(../webfonts/fa-brands-400.woff2) format("woff2"),
+    url(../webfonts/fa-brands-400.ttf) format("truetype");
+}
+@font-face {
+  font-family: "FontAwesome";
+  font-display: block;
+  src:
+    url(../webfonts/fa-regular-400.woff2) format("woff2"),
+    url(../webfonts/fa-regular-400.ttf) format("truetype");
+  unicode-range:
+    u+f003, u+f006, u+f014, u+f016-f017, u+f01a-f01b, u+f01d, u+f022, u+f03e,
+    u+f044, u+f046, u+f05c-f05d, u+f06e, u+f070, u+f087-f088, u+f08a, u+f094,
+    u+f096-f097, u+f09d, u+f0a0, u+f0a2, u+f0a4-f0a7, u+f0c5, u+f0c7,
+    u+f0e5-f0e6, u+f0eb, u+f0f6-f0f8, u+f10c, u+f114-f115, u+f118-f11a,
+    u+f11c-f11d, u+f133, u+f147, u+f14e, u+f150-f152, u+f185-f186, u+f18e,
+    u+f190-f192, u+f196, u+f1c1-f1c9, u+f1d9, u+f1db, u+f1e3, u+f1ea, u+f1f7,
+    u+f1f9, u+f20a, u+f247-f248, u+f24a, u+f24d, u+f255-f25b, u+f25d,
+    u+f271-f274, u+f278, u+f27b, u+f28c, u+f28e, u+f29c, u+f2b5, u+f2b7, u+f2ba,
+    u+f2bc, u+f2be, u+f2c0-f2c1, u+f2c3, u+f2d0, u+f2d2, u+f2d4, u+f2dc;
+}
+@font-face {
+  font-family: "FontAwesome";
+  font-display: block;
+  src:
+    url(../webfonts/fa-v4compatibility.woff2) format("woff2"),
+    url(../webfonts/fa-v4compatibility.ttf) format("truetype");
+  unicode-range:
+    u+f041, u+f047, u+f065-f066, u+f07d-f07e, u+f080, u+f08b, u+f08e, u+f090,
+    u+f09a, u+f0ac, u+f0ae, u+f0b2, u+f0d0, u+f0d6, u+f0e4, u+f0ec, u+f10a-f10b,
+    u+f123, u+f13e, u+f148-f149, u+f14c, u+f156, u+f15e, u+f160-f161, u+f163,
+    u+f175-f178, u+f195, u+f1f8, u+f219, u+f27a;
+}

--- a/oauth2-proxy-templates/error.html
+++ b/oauth2-proxy-templates/error.html
@@ -1,0 +1,114 @@
+{{define "error.html"}}
+<!doctype html>
+<html lang="en" charset="utf-8">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
+    <title>{{.StatusCode}} {{.Title}}</title>
+    <link rel="stylesheet" href="./msf.css" />
+    <link rel="stylesheet" href="./all.min.css" />
+
+    <script type="text/javascript">
+      document.addEventListener("DOMContentLoaded", function () {
+        let cardToggles = document.getElementsByClassName("card-toggle");
+        for (let i = 0; i < cardToggles.length; i++) {
+          cardToggles[i].addEventListener("click", (e) => {
+            e.currentTarget.parentElement.parentElement.childNodes[3].classList.toggle(
+              "is-hidden",
+            );
+          });
+        }
+      });
+    </script>
+
+    <style>
+      body {
+        height: 100vh;
+      }
+      .error-box {
+        margin: 1.25rem auto;
+        max-width: 600px;
+      }
+      .status-code {
+        font-size: 12rem;
+        font-weight: 600;
+      }
+      #more-info.card {
+        border: 1px solid #f0f0f0;
+      }
+      footer a {
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body class="has-background-light">
+    <section class="section">
+      <div class="box block error-box has-text-centered">
+        <div class="status-code">{{.StatusCode}}</div>
+        <div class="block">
+          <h1 class="subtitle is-1">{{.Title}}</h1>
+        </div>
+
+        {{ if or .Message .RequestID }}
+        <div id="more-info" class="block card is-fullwidth is-shadowless">
+          <header class="card-header is-shadowless">
+            <p class="card-header-title">More Info</p>
+            <a class="card-header-icon card-toggle">
+              <i class="fa fa-angle-down"></i>
+            </a>
+          </header>
+          <div class="card-content has-text-left is-hidden">
+            {{ if .Message }}
+            <div class="content">{{.Message}}</div>
+            {{ end }} {{ if .RequestID }}
+            <div class="content">Request ID: {{.RequestID}}</div>
+            {{ end }}
+          </div>
+        </div>
+        {{ end }} {{ if .Redirect }}
+        <hr />
+
+        <div class="columns">
+          <div class="column">
+            <form method="GET" action="{{.Redirect}}">
+              <button type="submit" class="button is-danger is-fullwidth">
+                Go back
+              </button>
+            </form>
+          </div>
+          <div class="column">
+            <form method="GET" action="{{.ProxyPrefix}}/sign_in">
+              <input type="hidden" name="rd" value="{{.Redirect}}" />
+              <button type="submit" class="button is-primary is-fullwidth">
+                Sign in
+              </button>
+            </form>
+          </div>
+        </div>
+        {{ end }}
+      </div>
+    </section>
+
+    <footer class="footer has-text-grey has-background-light is-size-7">
+      <div class="content has-text-centered">
+        {{ if eq .Footer "-" }} {{ else if eq .Footer ""}}
+        <p>
+          Secured with
+          <a
+            href="https://github.com/oauth2-proxy/oauth2-proxy#oauth2_proxy"
+            class="has-text-grey"
+            >OAuth2 Proxy</a
+          >
+          version {{.Version}}
+        </p>
+        {{ else }}
+        <p>{{.Footer}}</p>
+        {{ end }}
+      </div>
+    </footer>
+  </body>
+</html>
+{{end}}

--- a/oauth2-proxy-templates/msf.css
+++ b/oauth2-proxy-templates/msf.css
@@ -1,0 +1,13171 @@
+/*! bulma.io v0.9.4 | MIT License | github.com/jgthms/bulma */
+.button,
+.file-cta,
+.file-name,
+.input,
+.pagination-ellipsis,
+.pagination-link,
+.pagination-next,
+.pagination-previous,
+.select select,
+.textarea {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  align-items: center;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  box-shadow: none;
+  display: inline-flex;
+  font-size: 1rem;
+  height: 2.5em;
+  justify-content: flex-start;
+  line-height: 1.5;
+  padding-bottom: calc(0.5em - 1px);
+  padding-left: calc(0.75em - 1px);
+  padding-right: calc(0.75em - 1px);
+  padding-top: calc(0.5em - 1px);
+  position: relative;
+  vertical-align: top;
+}
+
+.button:active,
+.button:focus,
+.file-cta:active,
+.file-cta:focus,
+.file-name:active,
+.file-name:focus,
+.input:active,
+.input:focus,
+.is-active.button,
+.is-active.file-cta,
+.is-active.file-name,
+.is-active.input,
+.is-active.pagination-ellipsis,
+.is-active.pagination-link,
+.is-active.pagination-next,
+.is-active.pagination-previous,
+.is-active.textarea,
+.is-focused.button,
+.is-focused.file-cta,
+.is-focused.file-name,
+.is-focused.input,
+.is-focused.pagination-ellipsis,
+.is-focused.pagination-link,
+.is-focused.pagination-next,
+.is-focused.pagination-previous,
+.is-focused.textarea,
+.pagination-ellipsis:active,
+.pagination-ellipsis:focus,
+.pagination-link:active,
+.pagination-link:focus,
+.pagination-next:active,
+.pagination-next:focus,
+.pagination-previous:active,
+.pagination-previous:focus,
+.select select.is-active,
+.select select.is-focused,
+.select select:active,
+.select select:focus,
+.textarea:active,
+.textarea:focus {
+  outline: 0;
+}
+
+.button[disabled],
+.file-cta[disabled],
+.file-name[disabled],
+.input[disabled],
+.pagination-ellipsis[disabled],
+.pagination-link[disabled],
+.pagination-next[disabled],
+.pagination-previous[disabled],
+.select fieldset[disabled] select,
+.select select[disabled],
+.textarea[disabled],
+fieldset[disabled] .button,
+fieldset[disabled] .file-cta,
+fieldset[disabled] .file-name,
+fieldset[disabled] .input,
+fieldset[disabled] .pagination-ellipsis,
+fieldset[disabled] .pagination-link,
+fieldset[disabled] .pagination-next,
+fieldset[disabled] .pagination-previous,
+fieldset[disabled] .select select,
+fieldset[disabled] .textarea {
+  cursor: not-allowed;
+}
+
+.breadcrumb,
+.button,
+.file,
+.is-unselectable,
+.pagination-ellipsis,
+.pagination-link,
+.pagination-next,
+.pagination-previous,
+.tabs {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.navbar-link:not(.is-arrowless)::after,
+.select:not(.is-multiple):not(.is-loading)::after {
+  border: 3px solid transparent;
+  border-radius: 2px;
+  border-right: 0;
+  border-top: 0;
+  content: " ";
+  display: block;
+  height: 0.625em;
+  margin-top: -0.4375em;
+  pointer-events: none;
+  position: absolute;
+  top: 50%;
+  transform: rotate(-45deg);
+  transform-origin: center;
+  width: 0.625em;
+}
+
+.block:not(:last-child),
+.box:not(:last-child),
+.breadcrumb:not(:last-child),
+.content:not(:last-child),
+.level:not(:last-child),
+.message:not(:last-child),
+.notification:not(:last-child),
+.pagination:not(:last-child),
+.progress:not(:last-child),
+.subtitle:not(:last-child),
+.table-container:not(:last-child),
+.table:not(:last-child),
+.tabs:not(:last-child),
+.title:not(:last-child) {
+  margin-bottom: 1.5rem;
+}
+
+.delete,
+.modal-close {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  background-color: rgba(10, 10, 10, 0.2);
+  border: none;
+  border-radius: 9999px;
+  cursor: pointer;
+  pointer-events: auto;
+  display: inline-block;
+  flex-grow: 0;
+  flex-shrink: 0;
+  font-size: 0;
+  height: 20px;
+  max-height: 20px;
+  max-width: 20px;
+  min-height: 20px;
+  min-width: 20px;
+  outline: 0;
+  position: relative;
+  vertical-align: top;
+  width: 20px;
+}
+
+.delete::after,
+.delete::before,
+.modal-close::after,
+.modal-close::before {
+  background-color: #fff;
+  content: "";
+  display: block;
+  left: 50%;
+  position: absolute;
+  top: 50%;
+  transform: translateX(-50%) translateY(-50%) rotate(45deg);
+  transform-origin: center center;
+}
+
+.delete::before,
+.modal-close::before {
+  height: 2px;
+  width: 50%;
+}
+
+.delete::after,
+.modal-close::after {
+  height: 50%;
+  width: 2px;
+}
+
+.delete:focus,
+.delete:hover,
+.modal-close:focus,
+.modal-close:hover {
+  background-color: rgba(10, 10, 10, 0.3);
+}
+
+.delete:active,
+.modal-close:active {
+  background-color: rgba(10, 10, 10, 0.4);
+}
+
+.is-small.delete,
+.is-small.modal-close {
+  height: 16px;
+  max-height: 16px;
+  max-width: 16px;
+  min-height: 16px;
+  min-width: 16px;
+  width: 16px;
+}
+
+.is-medium.delete,
+.is-medium.modal-close {
+  height: 24px;
+  max-height: 24px;
+  max-width: 24px;
+  min-height: 24px;
+  min-width: 24px;
+  width: 24px;
+}
+
+.is-large.delete,
+.is-large.modal-close {
+  height: 32px;
+  max-height: 32px;
+  max-width: 32px;
+  min-height: 32px;
+  min-width: 32px;
+  width: 32px;
+}
+
+.button.is-loading::after,
+.control.is-loading::after,
+.loader,
+.select.is-loading::after {
+  -webkit-animation: spinAround 0.5s infinite linear;
+  animation: spinAround 0.5s infinite linear;
+  border: 2px solid #dbdbdb;
+  border-radius: 9999px;
+  border-right-color: transparent;
+  border-top-color: transparent;
+  content: "";
+  display: block;
+  height: 1em;
+  position: relative;
+  width: 1em;
+}
+
+.hero-video,
+.image.is-16by9 .has-ratio,
+.image.is-16by9 img,
+.image.is-1by1 .has-ratio,
+.image.is-1by1 img,
+.image.is-1by2 .has-ratio,
+.image.is-1by2 img,
+.image.is-1by3 .has-ratio,
+.image.is-1by3 img,
+.image.is-2by1 .has-ratio,
+.image.is-2by1 img,
+.image.is-2by3 .has-ratio,
+.image.is-2by3 img,
+.image.is-3by1 .has-ratio,
+.image.is-3by1 img,
+.image.is-3by2 .has-ratio,
+.image.is-3by2 img,
+.image.is-3by4 .has-ratio,
+.image.is-3by4 img,
+.image.is-3by5 .has-ratio,
+.image.is-3by5 img,
+.image.is-4by3 .has-ratio,
+.image.is-4by3 img,
+.image.is-4by5 .has-ratio,
+.image.is-4by5 img,
+.image.is-5by3 .has-ratio,
+.image.is-5by3 img,
+.image.is-5by4 .has-ratio,
+.image.is-5by4 img,
+.image.is-9by16 .has-ratio,
+.image.is-9by16 img,
+.image.is-square .has-ratio,
+.image.is-square img,
+.is-overlay,
+.modal,
+.modal-background {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.navbar-burger {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border: none;
+  color: currentColor;
+  font-family: inherit;
+  font-size: 1em;
+  margin: 0;
+  padding: 0;
+}
+
+/*! minireset.css v0.0.6 | MIT License | github.com/jgthms/minireset.css */
+blockquote,
+body,
+dd,
+dl,
+dt,
+fieldset,
+figure,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hr,
+html,
+iframe,
+legend,
+li,
+ol,
+p,
+pre,
+textarea,
+ul {
+  margin: 0;
+  padding: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: 100%;
+  font-weight: 400;
+}
+
+ul {
+  list-style: none;
+}
+
+button,
+input,
+select,
+textarea {
+  margin: 0;
+}
+
+html {
+  box-sizing: border-box;
+}
+
+*,
+::after,
+::before {
+  box-sizing: inherit;
+}
+
+img,
+video {
+  height: auto;
+  max-width: 100%;
+}
+
+iframe {
+  border: 0;
+}
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}
+
+td:not([align]),
+th:not([align]) {
+  text-align: inherit;
+}
+
+html {
+  background-color: #fff;
+  font-size: 16px;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  min-width: 300px;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  text-rendering: optimizeLegibility;
+  -webkit-text-size-adjust: 100%;
+  -moz-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+article,
+aside,
+figure,
+footer,
+header,
+hgroup,
+section {
+  display: block;
+}
+
+body,
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family:
+    BlinkMacSystemFont,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    "Fira Sans",
+    "Droid Sans",
+    "Helvetica Neue",
+    Helvetica,
+    Arial,
+    sans-serif;
+}
+
+code,
+pre {
+  -moz-osx-font-smoothing: auto;
+  -webkit-font-smoothing: auto;
+  font-family: monospace;
+}
+
+body {
+  color: #4a4a4a;
+  font-size: 1em;
+  font-weight: 400;
+  line-height: 1.5;
+}
+
+a {
+  color: #485fc7;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+a strong {
+  color: currentColor;
+}
+
+a:hover {
+  color: #363636;
+}
+
+code {
+  background-color: #f5f5f5;
+  color: #da1039;
+  font-size: 0.875em;
+  font-weight: 400;
+  padding: 0.25em 0.5em 0.25em;
+}
+
+hr {
+  background-color: #f5f5f5;
+  border: none;
+  display: block;
+  height: 2px;
+  margin: 1.5rem 0;
+}
+
+img {
+  height: auto;
+  max-width: 100%;
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+  vertical-align: baseline;
+}
+
+small {
+  font-size: 0.875em;
+}
+
+span {
+  font-style: inherit;
+  font-weight: inherit;
+}
+
+strong {
+  color: #363636;
+  font-weight: 700;
+}
+
+fieldset {
+  border: none;
+}
+
+pre {
+  -webkit-overflow-scrolling: touch;
+  background-color: #f5f5f5;
+  color: #4a4a4a;
+  font-size: 0.875em;
+  overflow-x: auto;
+  padding: 1.25rem 1.5rem;
+  white-space: pre;
+  word-wrap: normal;
+}
+
+pre code {
+  background-color: transparent;
+  color: currentColor;
+  font-size: 1em;
+  padding: 0;
+}
+
+table td,
+table th {
+  vertical-align: top;
+}
+
+table td:not([align]),
+table th:not([align]) {
+  text-align: inherit;
+}
+
+table th {
+  color: #363636;
+}
+
+@-webkit-keyframes spinAround {
+  from {
+    transform: rotate(0);
+  }
+  to {
+    transform: rotate(359deg);
+  }
+}
+
+@keyframes spinAround {
+  from {
+    transform: rotate(0);
+  }
+  to {
+    transform: rotate(359deg);
+  }
+}
+
+.box {
+  background-color: #fff;
+  border-radius: 6px;
+  box-shadow:
+    0 0.5em 1em -0.125em rgba(10, 10, 10, 0.1),
+    0 0 0 1px rgba(10, 10, 10, 0.02);
+  color: #4a4a4a;
+  display: block;
+  padding: 1.25rem;
+}
+
+a.box:focus,
+a.box:hover {
+  box-shadow:
+    0 0.5em 1em -0.125em rgba(10, 10, 10, 0.1),
+    0 0 0 1px #485fc7;
+}
+
+a.box:active {
+  box-shadow:
+    inset 0 1px 2px rgba(10, 10, 10, 0.2),
+    0 0 0 1px #485fc7;
+}
+
+.button {
+  background-color: #fff;
+  border-color: #dbdbdb;
+  border-width: 1px;
+  color: #363636;
+  cursor: pointer;
+  justify-content: center;
+  padding-bottom: calc(0.5em - 1px);
+  padding-left: 1em;
+  padding-right: 1em;
+  padding-top: calc(0.5em - 1px);
+  text-align: center;
+  white-space: nowrap;
+}
+
+.button strong {
+  color: inherit;
+}
+
+.button .icon,
+.button .icon.is-large,
+.button .icon.is-medium,
+.button .icon.is-small {
+  height: 1.5em;
+  width: 1.5em;
+}
+
+.button .icon:first-child:not(:last-child) {
+  margin-left: calc(-0.5em - 1px);
+  margin-right: 0.25em;
+}
+
+.button .icon:last-child:not(:first-child) {
+  margin-left: 0.25em;
+  margin-right: calc(-0.5em - 1px);
+}
+
+.button .icon:first-child:last-child {
+  margin-left: calc(-0.5em - 1px);
+  margin-right: calc(-0.5em - 1px);
+}
+
+.button.is-hovered,
+.button:hover {
+  border-color: #b5b5b5;
+  color: #363636;
+}
+
+.button.is-focused,
+.button:focus {
+  border-color: #485fc7;
+  color: #363636;
+}
+
+.button.is-focused:not(:active),
+.button:focus:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(72, 95, 199, 0.25);
+}
+
+.button.is-active,
+.button:active {
+  border-color: #4a4a4a;
+  color: #363636;
+}
+
+.button.is-text {
+  background-color: transparent;
+  border-color: transparent;
+  color: #4a4a4a;
+  text-decoration: underline;
+}
+
+.button.is-text.is-focused,
+.button.is-text.is-hovered,
+.button.is-text:focus,
+.button.is-text:hover {
+  background-color: #f5f5f5;
+  color: #363636;
+}
+
+.button.is-text.is-active,
+.button.is-text:active {
+  background-color: #e8e8e8;
+  color: #363636;
+}
+
+.button.is-text[disabled],
+fieldset[disabled] .button.is-text {
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.button.is-ghost {
+  background: 0 0;
+  border-color: transparent;
+  color: #485fc7;
+  text-decoration: none;
+}
+
+.button.is-ghost.is-hovered,
+.button.is-ghost:hover {
+  color: #485fc7;
+  text-decoration: underline;
+}
+
+.button.is-white {
+  background-color: #fff;
+  border-color: transparent;
+  color: #0a0a0a;
+}
+
+.button.is-white.is-hovered,
+.button.is-white:hover {
+  background-color: #f9f9f9;
+  border-color: transparent;
+  color: #0a0a0a;
+}
+
+.button.is-white.is-focused,
+.button.is-white:focus {
+  border-color: transparent;
+  color: #0a0a0a;
+}
+
+.button.is-white.is-focused:not(:active),
+.button.is-white:focus:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(255, 255, 255, 0.25);
+}
+
+.button.is-white.is-active,
+.button.is-white:active {
+  background-color: #f2f2f2;
+  border-color: transparent;
+  color: #0a0a0a;
+}
+
+.button.is-white[disabled],
+fieldset[disabled] .button.is-white {
+  background-color: #fff;
+  border-color: #fff;
+  box-shadow: none;
+}
+
+.button.is-white.is-inverted {
+  background-color: #0a0a0a;
+  color: #fff;
+}
+
+.button.is-white.is-inverted.is-hovered,
+.button.is-white.is-inverted:hover {
+  background-color: #000;
+}
+
+.button.is-white.is-inverted[disabled],
+fieldset[disabled] .button.is-white.is-inverted {
+  background-color: #0a0a0a;
+  border-color: transparent;
+  box-shadow: none;
+  color: #fff;
+}
+
+.button.is-white.is-loading::after {
+  border-color: transparent transparent #0a0a0a #0a0a0a !important;
+}
+
+.button.is-white.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+
+.button.is-white.is-outlined.is-focused,
+.button.is-white.is-outlined.is-hovered,
+.button.is-white.is-outlined:focus,
+.button.is-white.is-outlined:hover {
+  background-color: #fff;
+  border-color: #fff;
+  color: #0a0a0a;
+}
+
+.button.is-white.is-outlined.is-loading::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+
+.button.is-white.is-outlined.is-loading.is-focused::after,
+.button.is-white.is-outlined.is-loading.is-hovered::after,
+.button.is-white.is-outlined.is-loading:focus::after,
+.button.is-white.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #0a0a0a #0a0a0a !important;
+}
+
+.button.is-white.is-outlined[disabled],
+fieldset[disabled] .button.is-white.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  box-shadow: none;
+  color: #fff;
+}
+
+.button.is-white.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #0a0a0a;
+  color: #0a0a0a;
+}
+
+.button.is-white.is-inverted.is-outlined.is-focused,
+.button.is-white.is-inverted.is-outlined.is-hovered,
+.button.is-white.is-inverted.is-outlined:focus,
+.button.is-white.is-inverted.is-outlined:hover {
+  background-color: #0a0a0a;
+  color: #fff;
+}
+
+.button.is-white.is-inverted.is-outlined.is-loading.is-focused::after,
+.button.is-white.is-inverted.is-outlined.is-loading.is-hovered::after,
+.button.is-white.is-inverted.is-outlined.is-loading:focus::after,
+.button.is-white.is-inverted.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+
+.button.is-white.is-inverted.is-outlined[disabled],
+fieldset[disabled] .button.is-white.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #0a0a0a;
+  box-shadow: none;
+  color: #0a0a0a;
+}
+
+.button.is-black {
+  background-color: #0a0a0a;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-black.is-hovered,
+.button.is-black:hover {
+  background-color: #040404;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-black.is-focused,
+.button.is-black:focus {
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-black.is-focused:not(:active),
+.button.is-black:focus:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(10, 10, 10, 0.25);
+}
+
+.button.is-black.is-active,
+.button.is-black:active {
+  background-color: #000;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-black[disabled],
+fieldset[disabled] .button.is-black {
+  background-color: #0a0a0a;
+  border-color: #0a0a0a;
+  box-shadow: none;
+}
+
+.button.is-black.is-inverted {
+  background-color: #fff;
+  color: #0a0a0a;
+}
+
+.button.is-black.is-inverted.is-hovered,
+.button.is-black.is-inverted:hover {
+  background-color: #f2f2f2;
+}
+
+.button.is-black.is-inverted[disabled],
+fieldset[disabled] .button.is-black.is-inverted {
+  background-color: #fff;
+  border-color: transparent;
+  box-shadow: none;
+  color: #0a0a0a;
+}
+
+.button.is-black.is-loading::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+
+.button.is-black.is-outlined {
+  background-color: transparent;
+  border-color: #0a0a0a;
+  color: #0a0a0a;
+}
+
+.button.is-black.is-outlined.is-focused,
+.button.is-black.is-outlined.is-hovered,
+.button.is-black.is-outlined:focus,
+.button.is-black.is-outlined:hover {
+  background-color: #0a0a0a;
+  border-color: #0a0a0a;
+  color: #fff;
+}
+
+.button.is-black.is-outlined.is-loading::after {
+  border-color: transparent transparent #0a0a0a #0a0a0a !important;
+}
+
+.button.is-black.is-outlined.is-loading.is-focused::after,
+.button.is-black.is-outlined.is-loading.is-hovered::after,
+.button.is-black.is-outlined.is-loading:focus::after,
+.button.is-black.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+
+.button.is-black.is-outlined[disabled],
+fieldset[disabled] .button.is-black.is-outlined {
+  background-color: transparent;
+  border-color: #0a0a0a;
+  box-shadow: none;
+  color: #0a0a0a;
+}
+
+.button.is-black.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+
+.button.is-black.is-inverted.is-outlined.is-focused,
+.button.is-black.is-inverted.is-outlined.is-hovered,
+.button.is-black.is-inverted.is-outlined:focus,
+.button.is-black.is-inverted.is-outlined:hover {
+  background-color: #fff;
+  color: #0a0a0a;
+}
+
+.button.is-black.is-inverted.is-outlined.is-loading.is-focused::after,
+.button.is-black.is-inverted.is-outlined.is-loading.is-hovered::after,
+.button.is-black.is-inverted.is-outlined.is-loading:focus::after,
+.button.is-black.is-inverted.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #0a0a0a #0a0a0a !important;
+}
+
+.button.is-black.is-inverted.is-outlined[disabled],
+fieldset[disabled] .button.is-black.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  box-shadow: none;
+  color: #fff;
+}
+
+.button.is-light {
+  background-color: #f5f5f5;
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.button.is-light.is-hovered,
+.button.is-light:hover {
+  background-color: #eee;
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.button.is-light.is-focused,
+.button.is-light:focus {
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.button.is-light.is-focused:not(:active),
+.button.is-light:focus:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25);
+}
+
+.button.is-light.is-active,
+.button.is-light:active {
+  background-color: #e8e8e8;
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.button.is-light[disabled],
+fieldset[disabled] .button.is-light {
+  background-color: #f5f5f5;
+  border-color: #f5f5f5;
+  box-shadow: none;
+}
+
+.button.is-light.is-inverted {
+  background-color: rgba(0, 0, 0, 0.7);
+  color: #f5f5f5;
+}
+
+.button.is-light.is-inverted.is-hovered,
+.button.is-light.is-inverted:hover {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.button.is-light.is-inverted[disabled],
+fieldset[disabled] .button.is-light.is-inverted {
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: transparent;
+  box-shadow: none;
+  color: #f5f5f5;
+}
+
+.button.is-light.is-loading::after {
+  border-color: transparent transparent rgba(0, 0, 0, 0.7) rgba(0, 0, 0, 0.7) !important;
+}
+
+.button.is-light.is-outlined {
+  background-color: transparent;
+  border-color: #f5f5f5;
+  color: #f5f5f5;
+}
+
+.button.is-light.is-outlined.is-focused,
+.button.is-light.is-outlined.is-hovered,
+.button.is-light.is-outlined:focus,
+.button.is-light.is-outlined:hover {
+  background-color: #f5f5f5;
+  border-color: #f5f5f5;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.button.is-light.is-outlined.is-loading::after {
+  border-color: transparent transparent #f5f5f5 #f5f5f5 !important;
+}
+
+.button.is-light.is-outlined.is-loading.is-focused::after,
+.button.is-light.is-outlined.is-loading.is-hovered::after,
+.button.is-light.is-outlined.is-loading:focus::after,
+.button.is-light.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent rgba(0, 0, 0, 0.7) rgba(0, 0, 0, 0.7) !important;
+}
+
+.button.is-light.is-outlined[disabled],
+fieldset[disabled] .button.is-light.is-outlined {
+  background-color: transparent;
+  border-color: #f5f5f5;
+  box-shadow: none;
+  color: #f5f5f5;
+}
+
+.button.is-light.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: rgba(0, 0, 0, 0.7);
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.button.is-light.is-inverted.is-outlined.is-focused,
+.button.is-light.is-inverted.is-outlined.is-hovered,
+.button.is-light.is-inverted.is-outlined:focus,
+.button.is-light.is-inverted.is-outlined:hover {
+  background-color: rgba(0, 0, 0, 0.7);
+  color: #f5f5f5;
+}
+
+.button.is-light.is-inverted.is-outlined.is-loading.is-focused::after,
+.button.is-light.is-inverted.is-outlined.is-loading.is-hovered::after,
+.button.is-light.is-inverted.is-outlined.is-loading:focus::after,
+.button.is-light.is-inverted.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #f5f5f5 #f5f5f5 !important;
+}
+
+.button.is-light.is-inverted.is-outlined[disabled],
+fieldset[disabled] .button.is-light.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: rgba(0, 0, 0, 0.7);
+  box-shadow: none;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.button.is-dark {
+  background-color: #363636;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-dark.is-hovered,
+.button.is-dark:hover {
+  background-color: #2f2f2f;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-dark.is-focused,
+.button.is-dark:focus {
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-dark.is-focused:not(:active),
+.button.is-dark:focus:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(54, 54, 54, 0.25);
+}
+
+.button.is-dark.is-active,
+.button.is-dark:active {
+  background-color: #292929;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-dark[disabled],
+fieldset[disabled] .button.is-dark {
+  background-color: #363636;
+  border-color: #363636;
+  box-shadow: none;
+}
+
+.button.is-dark.is-inverted {
+  background-color: #fff;
+  color: #363636;
+}
+
+.button.is-dark.is-inverted.is-hovered,
+.button.is-dark.is-inverted:hover {
+  background-color: #f2f2f2;
+}
+
+.button.is-dark.is-inverted[disabled],
+fieldset[disabled] .button.is-dark.is-inverted {
+  background-color: #fff;
+  border-color: transparent;
+  box-shadow: none;
+  color: #363636;
+}
+
+.button.is-dark.is-loading::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+
+.button.is-dark.is-outlined {
+  background-color: transparent;
+  border-color: #363636;
+  color: #363636;
+}
+
+.button.is-dark.is-outlined.is-focused,
+.button.is-dark.is-outlined.is-hovered,
+.button.is-dark.is-outlined:focus,
+.button.is-dark.is-outlined:hover {
+  background-color: #363636;
+  border-color: #363636;
+  color: #fff;
+}
+
+.button.is-dark.is-outlined.is-loading::after {
+  border-color: transparent transparent #363636 #363636 !important;
+}
+
+.button.is-dark.is-outlined.is-loading.is-focused::after,
+.button.is-dark.is-outlined.is-loading.is-hovered::after,
+.button.is-dark.is-outlined.is-loading:focus::after,
+.button.is-dark.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+
+.button.is-dark.is-outlined[disabled],
+fieldset[disabled] .button.is-dark.is-outlined {
+  background-color: transparent;
+  border-color: #363636;
+  box-shadow: none;
+  color: #363636;
+}
+
+.button.is-dark.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+
+.button.is-dark.is-inverted.is-outlined.is-focused,
+.button.is-dark.is-inverted.is-outlined.is-hovered,
+.button.is-dark.is-inverted.is-outlined:focus,
+.button.is-dark.is-inverted.is-outlined:hover {
+  background-color: #fff;
+  color: #363636;
+}
+
+.button.is-dark.is-inverted.is-outlined.is-loading.is-focused::after,
+.button.is-dark.is-inverted.is-outlined.is-loading.is-hovered::after,
+.button.is-dark.is-inverted.is-outlined.is-loading:focus::after,
+.button.is-dark.is-inverted.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #363636 #363636 !important;
+}
+
+.button.is-dark.is-inverted.is-outlined[disabled],
+fieldset[disabled] .button.is-dark.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  box-shadow: none;
+  color: #fff;
+}
+
+.button.is-primary {
+  background-color: #ee0000;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-primary.is-hovered,
+.button.is-primary:hover {
+  background-color: #dd0000;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-primary.is-focused,
+.button.is-primary:focus {
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-primary.is-focused:not(:active),
+.button.is-primary:focus:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(0, 209, 178, 0.25);
+}
+
+.button.is-primary.is-active,
+.button.is-primary:active {
+  background-color: #cc1111;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-primary[disabled],
+fieldset[disabled] .button.is-primary {
+  background-color: #00d1b2;
+  border-color: #00d1b2;
+  box-shadow: none;
+}
+
+.button.is-primary.is-inverted {
+  background-color: #fff;
+  color: #00d1b2;
+}
+
+.button.is-primary.is-inverted.is-hovered,
+.button.is-primary.is-inverted:hover {
+  background-color: #f2f2f2;
+}
+
+.button.is-primary.is-inverted[disabled],
+fieldset[disabled] .button.is-primary.is-inverted {
+  background-color: #fff;
+  border-color: transparent;
+  box-shadow: none;
+  color: #00d1b2;
+}
+
+.button.is-primary.is-loading::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+
+.button.is-primary.is-outlined {
+  background-color: transparent;
+  border-color: #00d1b2;
+  color: #00d1b2;
+}
+
+.button.is-primary.is-outlined.is-focused,
+.button.is-primary.is-outlined.is-hovered,
+.button.is-primary.is-outlined:focus,
+.button.is-primary.is-outlined:hover {
+  background-color: #00d1b2;
+  border-color: #00d1b2;
+  color: #fff;
+}
+
+.button.is-primary.is-outlined.is-loading::after {
+  border-color: transparent transparent #00d1b2 #00d1b2 !important;
+}
+
+.button.is-primary.is-outlined.is-loading.is-focused::after,
+.button.is-primary.is-outlined.is-loading.is-hovered::after,
+.button.is-primary.is-outlined.is-loading:focus::after,
+.button.is-primary.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+
+.button.is-primary.is-outlined[disabled],
+fieldset[disabled] .button.is-primary.is-outlined {
+  background-color: transparent;
+  border-color: #00d1b2;
+  box-shadow: none;
+  color: #00d1b2;
+}
+
+.button.is-primary.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+
+.button.is-primary.is-inverted.is-outlined.is-focused,
+.button.is-primary.is-inverted.is-outlined.is-hovered,
+.button.is-primary.is-inverted.is-outlined:focus,
+.button.is-primary.is-inverted.is-outlined:hover {
+  background-color: #fff;
+  color: #00d1b2;
+}
+
+.button.is-primary.is-inverted.is-outlined.is-loading.is-focused::after,
+.button.is-primary.is-inverted.is-outlined.is-loading.is-hovered::after,
+.button.is-primary.is-inverted.is-outlined.is-loading:focus::after,
+.button.is-primary.is-inverted.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #00d1b2 #00d1b2 !important;
+}
+
+.button.is-primary.is-inverted.is-outlined[disabled],
+fieldset[disabled] .button.is-primary.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  box-shadow: none;
+  color: #fff;
+}
+
+.button.is-primary.is-light {
+  background-color: #ebfffc;
+  color: #00947e;
+}
+
+.button.is-primary.is-light.is-hovered,
+.button.is-primary.is-light:hover {
+  background-color: #defffa;
+  border-color: transparent;
+  color: #00947e;
+}
+
+.button.is-primary.is-light.is-active,
+.button.is-primary.is-light:active {
+  background-color: #d1fff8;
+  border-color: transparent;
+  color: #00947e;
+}
+
+.button.is-link {
+  background-color: #485fc7;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-link.is-hovered,
+.button.is-link:hover {
+  background-color: #3e56c4;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-link.is-focused,
+.button.is-link:focus {
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-link.is-focused:not(:active),
+.button.is-link:focus:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(72, 95, 199, 0.25);
+}
+
+.button.is-link.is-active,
+.button.is-link:active {
+  background-color: #3a51bb;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-link[disabled],
+fieldset[disabled] .button.is-link {
+  background-color: #485fc7;
+  border-color: #485fc7;
+  box-shadow: none;
+}
+
+.button.is-link.is-inverted {
+  background-color: #fff;
+  color: #485fc7;
+}
+
+.button.is-link.is-inverted.is-hovered,
+.button.is-link.is-inverted:hover {
+  background-color: #f2f2f2;
+}
+
+.button.is-link.is-inverted[disabled],
+fieldset[disabled] .button.is-link.is-inverted {
+  background-color: #fff;
+  border-color: transparent;
+  box-shadow: none;
+  color: #485fc7;
+}
+
+.button.is-link.is-loading::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+
+.button.is-link.is-outlined {
+  background-color: transparent;
+  border-color: #485fc7;
+  color: #485fc7;
+}
+
+.button.is-link.is-outlined.is-focused,
+.button.is-link.is-outlined.is-hovered,
+.button.is-link.is-outlined:focus,
+.button.is-link.is-outlined:hover {
+  background-color: #485fc7;
+  border-color: #485fc7;
+  color: #fff;
+}
+
+.button.is-link.is-outlined.is-loading::after {
+  border-color: transparent transparent #485fc7 #485fc7 !important;
+}
+
+.button.is-link.is-outlined.is-loading.is-focused::after,
+.button.is-link.is-outlined.is-loading.is-hovered::after,
+.button.is-link.is-outlined.is-loading:focus::after,
+.button.is-link.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+
+.button.is-link.is-outlined[disabled],
+fieldset[disabled] .button.is-link.is-outlined {
+  background-color: transparent;
+  border-color: #485fc7;
+  box-shadow: none;
+  color: #485fc7;
+}
+
+.button.is-link.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+
+.button.is-link.is-inverted.is-outlined.is-focused,
+.button.is-link.is-inverted.is-outlined.is-hovered,
+.button.is-link.is-inverted.is-outlined:focus,
+.button.is-link.is-inverted.is-outlined:hover {
+  background-color: #fff;
+  color: #485fc7;
+}
+
+.button.is-link.is-inverted.is-outlined.is-loading.is-focused::after,
+.button.is-link.is-inverted.is-outlined.is-loading.is-hovered::after,
+.button.is-link.is-inverted.is-outlined.is-loading:focus::after,
+.button.is-link.is-inverted.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #485fc7 #485fc7 !important;
+}
+
+.button.is-link.is-inverted.is-outlined[disabled],
+fieldset[disabled] .button.is-link.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  box-shadow: none;
+  color: #fff;
+}
+
+.button.is-link.is-light {
+  background-color: #eff1fa;
+  color: #3850b7;
+}
+
+.button.is-link.is-light.is-hovered,
+.button.is-link.is-light:hover {
+  background-color: #e6e9f7;
+  border-color: transparent;
+  color: #3850b7;
+}
+
+.button.is-link.is-light.is-active,
+.button.is-link.is-light:active {
+  background-color: #dce0f4;
+  border-color: transparent;
+  color: #3850b7;
+}
+
+.button.is-info {
+  background-color: #3e8ed0;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-info.is-hovered,
+.button.is-info:hover {
+  background-color: #3488ce;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-info.is-focused,
+.button.is-info:focus {
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-info.is-focused:not(:active),
+.button.is-info:focus:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(62, 142, 208, 0.25);
+}
+
+.button.is-info.is-active,
+.button.is-info:active {
+  background-color: #3082c5;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-info[disabled],
+fieldset[disabled] .button.is-info {
+  background-color: #3e8ed0;
+  border-color: #3e8ed0;
+  box-shadow: none;
+}
+
+.button.is-info.is-inverted {
+  background-color: #fff;
+  color: #3e8ed0;
+}
+
+.button.is-info.is-inverted.is-hovered,
+.button.is-info.is-inverted:hover {
+  background-color: #f2f2f2;
+}
+
+.button.is-info.is-inverted[disabled],
+fieldset[disabled] .button.is-info.is-inverted {
+  background-color: #fff;
+  border-color: transparent;
+  box-shadow: none;
+  color: #3e8ed0;
+}
+
+.button.is-info.is-loading::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+
+.button.is-info.is-outlined {
+  background-color: transparent;
+  border-color: #3e8ed0;
+  color: #3e8ed0;
+}
+
+.button.is-info.is-outlined.is-focused,
+.button.is-info.is-outlined.is-hovered,
+.button.is-info.is-outlined:focus,
+.button.is-info.is-outlined:hover {
+  background-color: #3e8ed0;
+  border-color: #3e8ed0;
+  color: #fff;
+}
+
+.button.is-info.is-outlined.is-loading::after {
+  border-color: transparent transparent #3e8ed0 #3e8ed0 !important;
+}
+
+.button.is-info.is-outlined.is-loading.is-focused::after,
+.button.is-info.is-outlined.is-loading.is-hovered::after,
+.button.is-info.is-outlined.is-loading:focus::after,
+.button.is-info.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+
+.button.is-info.is-outlined[disabled],
+fieldset[disabled] .button.is-info.is-outlined {
+  background-color: transparent;
+  border-color: #3e8ed0;
+  box-shadow: none;
+  color: #3e8ed0;
+}
+
+.button.is-info.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+
+.button.is-info.is-inverted.is-outlined.is-focused,
+.button.is-info.is-inverted.is-outlined.is-hovered,
+.button.is-info.is-inverted.is-outlined:focus,
+.button.is-info.is-inverted.is-outlined:hover {
+  background-color: #fff;
+  color: #3e8ed0;
+}
+
+.button.is-info.is-inverted.is-outlined.is-loading.is-focused::after,
+.button.is-info.is-inverted.is-outlined.is-loading.is-hovered::after,
+.button.is-info.is-inverted.is-outlined.is-loading:focus::after,
+.button.is-info.is-inverted.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #3e8ed0 #3e8ed0 !important;
+}
+
+.button.is-info.is-inverted.is-outlined[disabled],
+fieldset[disabled] .button.is-info.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  box-shadow: none;
+  color: #fff;
+}
+
+.button.is-info.is-light {
+  background-color: #eff5fb;
+  color: #296fa8;
+}
+
+.button.is-info.is-light.is-hovered,
+.button.is-info.is-light:hover {
+  background-color: #e4eff9;
+  border-color: transparent;
+  color: #296fa8;
+}
+
+.button.is-info.is-light.is-active,
+.button.is-info.is-light:active {
+  background-color: #dae9f6;
+  border-color: transparent;
+  color: #296fa8;
+}
+
+.button.is-success {
+  background-color: #48c78e;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-success.is-hovered,
+.button.is-success:hover {
+  background-color: #3ec487;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-success.is-focused,
+.button.is-success:focus {
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-success.is-focused:not(:active),
+.button.is-success:focus:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(72, 199, 142, 0.25);
+}
+
+.button.is-success.is-active,
+.button.is-success:active {
+  background-color: #3abb81;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-success[disabled],
+fieldset[disabled] .button.is-success {
+  background-color: #48c78e;
+  border-color: #48c78e;
+  box-shadow: none;
+}
+
+.button.is-success.is-inverted {
+  background-color: #fff;
+  color: #48c78e;
+}
+
+.button.is-success.is-inverted.is-hovered,
+.button.is-success.is-inverted:hover {
+  background-color: #f2f2f2;
+}
+
+.button.is-success.is-inverted[disabled],
+fieldset[disabled] .button.is-success.is-inverted {
+  background-color: #fff;
+  border-color: transparent;
+  box-shadow: none;
+  color: #48c78e;
+}
+
+.button.is-success.is-loading::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+
+.button.is-success.is-outlined {
+  background-color: transparent;
+  border-color: #48c78e;
+  color: #48c78e;
+}
+
+.button.is-success.is-outlined.is-focused,
+.button.is-success.is-outlined.is-hovered,
+.button.is-success.is-outlined:focus,
+.button.is-success.is-outlined:hover {
+  background-color: #48c78e;
+  border-color: #48c78e;
+  color: #fff;
+}
+
+.button.is-success.is-outlined.is-loading::after {
+  border-color: transparent transparent #48c78e #48c78e !important;
+}
+
+.button.is-success.is-outlined.is-loading.is-focused::after,
+.button.is-success.is-outlined.is-loading.is-hovered::after,
+.button.is-success.is-outlined.is-loading:focus::after,
+.button.is-success.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+
+.button.is-success.is-outlined[disabled],
+fieldset[disabled] .button.is-success.is-outlined {
+  background-color: transparent;
+  border-color: #48c78e;
+  box-shadow: none;
+  color: #48c78e;
+}
+
+.button.is-success.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+
+.button.is-success.is-inverted.is-outlined.is-focused,
+.button.is-success.is-inverted.is-outlined.is-hovered,
+.button.is-success.is-inverted.is-outlined:focus,
+.button.is-success.is-inverted.is-outlined:hover {
+  background-color: #fff;
+  color: #48c78e;
+}
+
+.button.is-success.is-inverted.is-outlined.is-loading.is-focused::after,
+.button.is-success.is-inverted.is-outlined.is-loading.is-hovered::after,
+.button.is-success.is-inverted.is-outlined.is-loading:focus::after,
+.button.is-success.is-inverted.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #48c78e #48c78e !important;
+}
+
+.button.is-success.is-inverted.is-outlined[disabled],
+fieldset[disabled] .button.is-success.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  box-shadow: none;
+  color: #fff;
+}
+
+.button.is-success.is-light {
+  background-color: #effaf5;
+  color: #257953;
+}
+
+.button.is-success.is-light.is-hovered,
+.button.is-success.is-light:hover {
+  background-color: #e6f7ef;
+  border-color: transparent;
+  color: #257953;
+}
+
+.button.is-success.is-light.is-active,
+.button.is-success.is-light:active {
+  background-color: #dcf4e9;
+  border-color: transparent;
+  color: #257953;
+}
+
+.button.is-warning {
+  background-color: #ffe08a;
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.button.is-warning.is-hovered,
+.button.is-warning:hover {
+  background-color: #ffdc7d;
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.button.is-warning.is-focused,
+.button.is-warning:focus {
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.button.is-warning.is-focused:not(:active),
+.button.is-warning:focus:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(255, 224, 138, 0.25);
+}
+
+.button.is-warning.is-active,
+.button.is-warning:active {
+  background-color: #ffd970;
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.button.is-warning[disabled],
+fieldset[disabled] .button.is-warning {
+  background-color: #ffe08a;
+  border-color: #ffe08a;
+  box-shadow: none;
+}
+
+.button.is-warning.is-inverted {
+  background-color: rgba(0, 0, 0, 0.7);
+  color: #ffe08a;
+}
+
+.button.is-warning.is-inverted.is-hovered,
+.button.is-warning.is-inverted:hover {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.button.is-warning.is-inverted[disabled],
+fieldset[disabled] .button.is-warning.is-inverted {
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: transparent;
+  box-shadow: none;
+  color: #ffe08a;
+}
+
+.button.is-warning.is-loading::after {
+  border-color: transparent transparent rgba(0, 0, 0, 0.7) rgba(0, 0, 0, 0.7) !important;
+}
+
+.button.is-warning.is-outlined {
+  background-color: transparent;
+  border-color: #ffe08a;
+  color: #ffe08a;
+}
+
+.button.is-warning.is-outlined.is-focused,
+.button.is-warning.is-outlined.is-hovered,
+.button.is-warning.is-outlined:focus,
+.button.is-warning.is-outlined:hover {
+  background-color: #ffe08a;
+  border-color: #ffe08a;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.button.is-warning.is-outlined.is-loading::after {
+  border-color: transparent transparent #ffe08a #ffe08a !important;
+}
+
+.button.is-warning.is-outlined.is-loading.is-focused::after,
+.button.is-warning.is-outlined.is-loading.is-hovered::after,
+.button.is-warning.is-outlined.is-loading:focus::after,
+.button.is-warning.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent rgba(0, 0, 0, 0.7) rgba(0, 0, 0, 0.7) !important;
+}
+
+.button.is-warning.is-outlined[disabled],
+fieldset[disabled] .button.is-warning.is-outlined {
+  background-color: transparent;
+  border-color: #ffe08a;
+  box-shadow: none;
+  color: #ffe08a;
+}
+
+.button.is-warning.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: rgba(0, 0, 0, 0.7);
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.button.is-warning.is-inverted.is-outlined.is-focused,
+.button.is-warning.is-inverted.is-outlined.is-hovered,
+.button.is-warning.is-inverted.is-outlined:focus,
+.button.is-warning.is-inverted.is-outlined:hover {
+  background-color: rgba(0, 0, 0, 0.7);
+  color: #ffe08a;
+}
+
+.button.is-warning.is-inverted.is-outlined.is-loading.is-focused::after,
+.button.is-warning.is-inverted.is-outlined.is-loading.is-hovered::after,
+.button.is-warning.is-inverted.is-outlined.is-loading:focus::after,
+.button.is-warning.is-inverted.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #ffe08a #ffe08a !important;
+}
+
+.button.is-warning.is-inverted.is-outlined[disabled],
+fieldset[disabled] .button.is-warning.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: rgba(0, 0, 0, 0.7);
+  box-shadow: none;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.button.is-warning.is-light {
+  background-color: #fffaeb;
+  color: #946c00;
+}
+
+.button.is-warning.is-light.is-hovered,
+.button.is-warning.is-light:hover {
+  background-color: #fff6de;
+  border-color: transparent;
+  color: #946c00;
+}
+
+.button.is-warning.is-light.is-active,
+.button.is-warning.is-light:active {
+  background-color: #fff3d1;
+  border-color: transparent;
+  color: #946c00;
+}
+
+.button.is-danger {
+  background-color: #f14668;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-danger.is-hovered,
+.button.is-danger:hover {
+  background-color: #f03a5f;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-danger.is-focused,
+.button.is-danger:focus {
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-danger.is-focused:not(:active),
+.button.is-danger:focus:not(:active) {
+  box-shadow: 0 0 0 0.125em rgba(241, 70, 104, 0.25);
+}
+
+.button.is-danger.is-active,
+.button.is-danger:active {
+  background-color: #ef2e55;
+  border-color: transparent;
+  color: #fff;
+}
+
+.button.is-danger[disabled],
+fieldset[disabled] .button.is-danger {
+  background-color: #f14668;
+  border-color: #f14668;
+  box-shadow: none;
+}
+
+.button.is-danger.is-inverted {
+  background-color: #fff;
+  color: #f14668;
+}
+
+.button.is-danger.is-inverted.is-hovered,
+.button.is-danger.is-inverted:hover {
+  background-color: #f2f2f2;
+}
+
+.button.is-danger.is-inverted[disabled],
+fieldset[disabled] .button.is-danger.is-inverted {
+  background-color: #fff;
+  border-color: transparent;
+  box-shadow: none;
+  color: #f14668;
+}
+
+.button.is-danger.is-loading::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+
+.button.is-danger.is-outlined {
+  background-color: transparent;
+  border-color: #f14668;
+  color: #f14668;
+}
+
+.button.is-danger.is-outlined.is-focused,
+.button.is-danger.is-outlined.is-hovered,
+.button.is-danger.is-outlined:focus,
+.button.is-danger.is-outlined:hover {
+  background-color: #f14668;
+  border-color: #f14668;
+  color: #fff;
+}
+
+.button.is-danger.is-outlined.is-loading::after {
+  border-color: transparent transparent #f14668 #f14668 !important;
+}
+
+.button.is-danger.is-outlined.is-loading.is-focused::after,
+.button.is-danger.is-outlined.is-loading.is-hovered::after,
+.button.is-danger.is-outlined.is-loading:focus::after,
+.button.is-danger.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #fff #fff !important;
+}
+
+.button.is-danger.is-outlined[disabled],
+fieldset[disabled] .button.is-danger.is-outlined {
+  background-color: transparent;
+  border-color: #f14668;
+  box-shadow: none;
+  color: #f14668;
+}
+
+.button.is-danger.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  color: #fff;
+}
+
+.button.is-danger.is-inverted.is-outlined.is-focused,
+.button.is-danger.is-inverted.is-outlined.is-hovered,
+.button.is-danger.is-inverted.is-outlined:focus,
+.button.is-danger.is-inverted.is-outlined:hover {
+  background-color: #fff;
+  color: #f14668;
+}
+
+.button.is-danger.is-inverted.is-outlined.is-loading.is-focused::after,
+.button.is-danger.is-inverted.is-outlined.is-loading.is-hovered::after,
+.button.is-danger.is-inverted.is-outlined.is-loading:focus::after,
+.button.is-danger.is-inverted.is-outlined.is-loading:hover::after {
+  border-color: transparent transparent #f14668 #f14668 !important;
+}
+
+.button.is-danger.is-inverted.is-outlined[disabled],
+fieldset[disabled] .button.is-danger.is-inverted.is-outlined {
+  background-color: transparent;
+  border-color: #fff;
+  box-shadow: none;
+  color: #fff;
+}
+
+.button.is-danger.is-light {
+  background-color: #feecf0;
+  color: #cc0f35;
+}
+
+.button.is-danger.is-light.is-hovered,
+.button.is-danger.is-light:hover {
+  background-color: #fde0e6;
+  border-color: transparent;
+  color: #cc0f35;
+}
+
+.button.is-danger.is-light.is-active,
+.button.is-danger.is-light:active {
+  background-color: #fcd4dc;
+  border-color: transparent;
+  color: #cc0f35;
+}
+
+.button.is-small {
+  font-size: 0.75rem;
+}
+
+.button.is-small:not(.is-rounded) {
+  border-radius: 2px;
+}
+
+.button.is-normal {
+  font-size: 1rem;
+}
+
+.button.is-medium {
+  font-size: 1.25rem;
+}
+
+.button.is-large {
+  font-size: 1.5rem;
+}
+
+.button[disabled],
+fieldset[disabled] .button {
+  background-color: #fff;
+  border-color: #dbdbdb;
+  box-shadow: none;
+  opacity: 0.5;
+}
+
+.button.is-fullwidth {
+  display: flex;
+  width: 100%;
+}
+
+.button.is-loading {
+  color: transparent !important;
+  pointer-events: none;
+}
+
+.button.is-loading::after {
+  position: absolute;
+  left: calc(50% - (1em * 0.5));
+  top: calc(50% - (1em * 0.5));
+  position: absolute !important;
+}
+
+.button.is-static {
+  background-color: #f5f5f5;
+  border-color: #dbdbdb;
+  color: #7a7a7a;
+  box-shadow: none;
+  pointer-events: none;
+}
+
+.button.is-rounded {
+  border-radius: 9999px;
+  padding-left: calc(1em + 0.25em);
+  padding-right: calc(1em + 0.25em);
+}
+
+.buttons {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+.buttons .button {
+  margin-bottom: 0.5rem;
+}
+
+.buttons .button:not(:last-child):not(.is-fullwidth) {
+  margin-right: 0.5rem;
+}
+
+.buttons:last-child {
+  margin-bottom: -0.5rem;
+}
+
+.buttons:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+.buttons.are-small .button:not(.is-normal):not(.is-medium):not(.is-large) {
+  font-size: 0.75rem;
+}
+
+.buttons.are-small
+  .button:not(.is-normal):not(.is-medium):not(.is-large):not(.is-rounded) {
+  border-radius: 2px;
+}
+
+.buttons.are-medium .button:not(.is-small):not(.is-normal):not(.is-large) {
+  font-size: 1.25rem;
+}
+
+.buttons.are-large .button:not(.is-small):not(.is-normal):not(.is-medium) {
+  font-size: 1.5rem;
+}
+
+.buttons.has-addons .button:not(:first-child) {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.buttons.has-addons .button:not(:last-child) {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+  margin-right: -1px;
+}
+
+.buttons.has-addons .button:last-child {
+  margin-right: 0;
+}
+
+.buttons.has-addons .button.is-hovered,
+.buttons.has-addons .button:hover {
+  z-index: 2;
+}
+
+.buttons.has-addons .button.is-active,
+.buttons.has-addons .button.is-focused,
+.buttons.has-addons .button.is-selected,
+.buttons.has-addons .button:active,
+.buttons.has-addons .button:focus {
+  z-index: 3;
+}
+
+.buttons.has-addons .button.is-active:hover,
+.buttons.has-addons .button.is-focused:hover,
+.buttons.has-addons .button.is-selected:hover,
+.buttons.has-addons .button:active:hover,
+.buttons.has-addons .button:focus:hover {
+  z-index: 4;
+}
+
+.buttons.has-addons .button.is-expanded {
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+.buttons.is-centered {
+  justify-content: center;
+}
+
+.buttons.is-centered:not(.has-addons) .button:not(.is-fullwidth) {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+.buttons.is-right {
+  justify-content: flex-end;
+}
+
+.buttons.is-right:not(.has-addons) .button:not(.is-fullwidth) {
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}
+
+@media screen and (max-width: 768px) {
+  .button.is-responsive.is-small {
+    font-size: 0.5625rem;
+  }
+
+  .button.is-responsive,
+  .button.is-responsive.is-normal {
+    font-size: 0.65625rem;
+  }
+
+  .button.is-responsive.is-medium {
+    font-size: 0.75rem;
+  }
+
+  .button.is-responsive.is-large {
+    font-size: 1rem;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .button.is-responsive.is-small {
+    font-size: 0.65625rem;
+  }
+
+  .button.is-responsive,
+  .button.is-responsive.is-normal {
+    font-size: 0.75rem;
+  }
+
+  .button.is-responsive.is-medium {
+    font-size: 1rem;
+  }
+
+  .button.is-responsive.is-large {
+    font-size: 1.25rem;
+  }
+}
+
+.container {
+  flex-grow: 1;
+  margin: 0 auto;
+  position: relative;
+  width: auto;
+}
+
+.container.is-fluid {
+  max-width: none !important;
+  padding-left: 32px;
+  padding-right: 32px;
+  width: 100%;
+}
+
+@media screen and (min-width: 1024px) {
+  .container {
+    max-width: 960px;
+  }
+}
+
+@media screen and (max-width: 1215px) {
+  .container.is-widescreen:not(.is-max-desktop) {
+    max-width: 1152px;
+  }
+}
+
+@media screen and (max-width: 1407px) {
+  .container.is-fullhd:not(.is-max-desktop):not(.is-max-widescreen) {
+    max-width: 1344px;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .container:not(.is-max-desktop) {
+    max-width: 1152px;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .container:not(.is-max-desktop):not(.is-max-widescreen) {
+    max-width: 1344px;
+  }
+}
+
+.content li + li {
+  margin-top: 0.25em;
+}
+
+.content blockquote:not(:last-child),
+.content dl:not(:last-child),
+.content ol:not(:last-child),
+.content p:not(:last-child),
+.content pre:not(:last-child),
+.content table:not(:last-child),
+.content ul:not(:last-child) {
+  margin-bottom: 1em;
+}
+
+.content h1,
+.content h2,
+.content h3,
+.content h4,
+.content h5,
+.content h6 {
+  color: #363636;
+  font-weight: 600;
+  line-height: 1.125;
+}
+
+.content h1 {
+  font-size: 2em;
+  margin-bottom: 0.5em;
+}
+
+.content h1:not(:first-child) {
+  margin-top: 1em;
+}
+
+.content h2 {
+  font-size: 1.75em;
+  margin-bottom: 0.5714em;
+}
+
+.content h2:not(:first-child) {
+  margin-top: 1.1428em;
+}
+
+.content h3 {
+  font-size: 1.5em;
+  margin-bottom: 0.6666em;
+}
+
+.content h3:not(:first-child) {
+  margin-top: 1.3333em;
+}
+
+.content h4 {
+  font-size: 1.25em;
+  margin-bottom: 0.8em;
+}
+
+.content h5 {
+  font-size: 1.125em;
+  margin-bottom: 0.8888em;
+}
+
+.content h6 {
+  font-size: 1em;
+  margin-bottom: 1em;
+}
+
+.content blockquote {
+  background-color: #f5f5f5;
+  border-left: 5px solid #dbdbdb;
+  padding: 1.25em 1.5em;
+}
+
+.content ol {
+  list-style-position: outside;
+  margin-left: 2em;
+  margin-top: 1em;
+}
+
+.content ol:not([type]) {
+  list-style-type: decimal;
+}
+
+.content ol:not([type]).is-lower-alpha {
+  list-style-type: lower-alpha;
+}
+
+.content ol:not([type]).is-lower-roman {
+  list-style-type: lower-roman;
+}
+
+.content ol:not([type]).is-upper-alpha {
+  list-style-type: upper-alpha;
+}
+
+.content ol:not([type]).is-upper-roman {
+  list-style-type: upper-roman;
+}
+
+.content ul {
+  list-style: disc outside;
+  margin-left: 2em;
+  margin-top: 1em;
+}
+
+.content ul ul {
+  list-style-type: circle;
+  margin-top: 0.5em;
+}
+
+.content ul ul ul {
+  list-style-type: square;
+}
+
+.content dd {
+  margin-left: 2em;
+}
+
+.content figure {
+  margin-left: 2em;
+  margin-right: 2em;
+  text-align: center;
+}
+
+.content figure:not(:first-child) {
+  margin-top: 2em;
+}
+
+.content figure:not(:last-child) {
+  margin-bottom: 2em;
+}
+
+.content figure img {
+  display: inline-block;
+}
+
+.content figure figcaption {
+  font-style: italic;
+}
+
+.content pre {
+  -webkit-overflow-scrolling: touch;
+  overflow-x: auto;
+  padding: 1.25em 1.5em;
+  white-space: pre;
+  word-wrap: normal;
+}
+
+.content sub,
+.content sup {
+  font-size: 75%;
+}
+
+.content table {
+  width: 100%;
+}
+
+.content table td,
+.content table th {
+  border: 1px solid #dbdbdb;
+  border-width: 0 0 1px;
+  padding: 0.5em 0.75em;
+  vertical-align: top;
+}
+
+.content table th {
+  color: #363636;
+}
+
+.content table th:not([align]) {
+  text-align: inherit;
+}
+
+.content table thead td,
+.content table thead th {
+  border-width: 0 0 2px;
+  color: #363636;
+}
+
+.content table tfoot td,
+.content table tfoot th {
+  border-width: 2px 0 0;
+  color: #363636;
+}
+
+.content table tbody tr:last-child td,
+.content table tbody tr:last-child th {
+  border-bottom-width: 0;
+}
+
+.content .tabs li + li {
+  margin-top: 0;
+}
+
+.content.is-small {
+  font-size: 0.75rem;
+}
+
+.content.is-normal {
+  font-size: 1rem;
+}
+
+.content.is-medium {
+  font-size: 1.25rem;
+}
+
+.content.is-large {
+  font-size: 1.5rem;
+}
+
+.icon {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  height: 1.5rem;
+  width: 1.5rem;
+}
+
+.icon.is-small {
+  height: 1rem;
+  width: 1rem;
+}
+
+.icon.is-medium {
+  height: 2rem;
+  width: 2rem;
+}
+
+.icon.is-large {
+  height: 3rem;
+  width: 3rem;
+}
+
+.icon-text {
+  align-items: flex-start;
+  color: inherit;
+  display: inline-flex;
+  flex-wrap: wrap;
+  line-height: 1.5rem;
+  vertical-align: top;
+}
+
+.icon-text .icon {
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+
+.icon-text .icon:not(:last-child) {
+  margin-right: 0.25em;
+}
+
+.icon-text .icon:not(:first-child) {
+  margin-left: 0.25em;
+}
+
+div.icon-text {
+  display: flex;
+}
+
+.image {
+  display: block;
+  position: relative;
+}
+
+.image img {
+  display: block;
+  height: auto;
+  width: 100%;
+}
+
+.image img.is-rounded {
+  border-radius: 9999px;
+}
+
+.image.is-fullwidth {
+  width: 100%;
+}
+
+.image.is-16by9 .has-ratio,
+.image.is-16by9 img,
+.image.is-1by1 .has-ratio,
+.image.is-1by1 img,
+.image.is-1by2 .has-ratio,
+.image.is-1by2 img,
+.image.is-1by3 .has-ratio,
+.image.is-1by3 img,
+.image.is-2by1 .has-ratio,
+.image.is-2by1 img,
+.image.is-2by3 .has-ratio,
+.image.is-2by3 img,
+.image.is-3by1 .has-ratio,
+.image.is-3by1 img,
+.image.is-3by2 .has-ratio,
+.image.is-3by2 img,
+.image.is-3by4 .has-ratio,
+.image.is-3by4 img,
+.image.is-3by5 .has-ratio,
+.image.is-3by5 img,
+.image.is-4by3 .has-ratio,
+.image.is-4by3 img,
+.image.is-4by5 .has-ratio,
+.image.is-4by5 img,
+.image.is-5by3 .has-ratio,
+.image.is-5by3 img,
+.image.is-5by4 .has-ratio,
+.image.is-5by4 img,
+.image.is-9by16 .has-ratio,
+.image.is-9by16 img,
+.image.is-square .has-ratio,
+.image.is-square img {
+  height: 100%;
+  width: 100%;
+}
+
+.image.is-1by1,
+.image.is-square {
+  padding-top: 100%;
+}
+
+.image.is-5by4 {
+  padding-top: 80%;
+}
+
+.image.is-4by3 {
+  padding-top: 75%;
+}
+
+.image.is-3by2 {
+  padding-top: 66.6666%;
+}
+
+.image.is-5by3 {
+  padding-top: 60%;
+}
+
+.image.is-16by9 {
+  padding-top: 56.25%;
+}
+
+.image.is-2by1 {
+  padding-top: 50%;
+}
+
+.image.is-3by1 {
+  padding-top: 33.3333%;
+}
+
+.image.is-4by5 {
+  padding-top: 125%;
+}
+
+.image.is-3by4 {
+  padding-top: 133.3333%;
+}
+
+.image.is-2by3 {
+  padding-top: 150%;
+}
+
+.image.is-3by5 {
+  padding-top: 166.6666%;
+}
+
+.image.is-9by16 {
+  padding-top: 177.7777%;
+}
+
+.image.is-1by2 {
+  padding-top: 200%;
+}
+
+.image.is-1by3 {
+  padding-top: 300%;
+}
+
+.image.is-16x16 {
+  height: 16px;
+  width: 16px;
+}
+
+.image.is-24x24 {
+  height: 24px;
+  width: 24px;
+}
+
+.image.is-32x32 {
+  height: 32px;
+  width: 32px;
+}
+
+.image.is-48x48 {
+  height: 48px;
+  width: 48px;
+}
+
+.image.is-64x64 {
+  height: 64px;
+  width: 64px;
+}
+
+.image.is-96x96 {
+  height: 96px;
+  width: 96px;
+}
+
+.image.is-128x128 {
+  height: 128px;
+  width: 128px;
+}
+
+.notification {
+  background-color: #f5f5f5;
+  border-radius: 4px;
+  position: relative;
+  padding: 1.25rem 2.5rem 1.25rem 1.5rem;
+}
+
+.notification a:not(.button):not(.dropdown-item) {
+  color: currentColor;
+  text-decoration: underline;
+}
+
+.notification strong {
+  color: currentColor;
+}
+
+.notification code,
+.notification pre {
+  background: #fff;
+}
+
+.notification pre code {
+  background: 0 0;
+}
+
+.notification > .delete {
+  right: 0.5rem;
+  position: absolute;
+  top: 0.5rem;
+}
+
+.notification .content,
+.notification .subtitle,
+.notification .title {
+  color: currentColor;
+}
+
+.notification.is-white {
+  background-color: #fff;
+  color: #0a0a0a;
+}
+
+.notification.is-black {
+  background-color: #0a0a0a;
+  color: #fff;
+}
+
+.notification.is-light {
+  background-color: #f5f5f5;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.notification.is-dark {
+  background-color: #363636;
+  color: #fff;
+}
+
+.notification.is-primary {
+  background-color: #00d1b2;
+  color: #fff;
+}
+
+.notification.is-primary.is-light {
+  background-color: #ebfffc;
+  color: #00947e;
+}
+
+.notification.is-link {
+  background-color: #485fc7;
+  color: #fff;
+}
+
+.notification.is-link.is-light {
+  background-color: #eff1fa;
+  color: #3850b7;
+}
+
+.notification.is-info {
+  background-color: #3e8ed0;
+  color: #fff;
+}
+
+.notification.is-info.is-light {
+  background-color: #eff5fb;
+  color: #296fa8;
+}
+
+.notification.is-success {
+  background-color: #48c78e;
+  color: #fff;
+}
+
+.notification.is-success.is-light {
+  background-color: #effaf5;
+  color: #257953;
+}
+
+.notification.is-warning {
+  background-color: #ffe08a;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.notification.is-warning.is-light {
+  background-color: #fffaeb;
+  color: #946c00;
+}
+
+.notification.is-danger {
+  background-color: #f14668;
+  color: #fff;
+}
+
+.notification.is-danger.is-light {
+  background-color: #feecf0;
+  color: #cc0f35;
+}
+
+.progress {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  border: none;
+  border-radius: 9999px;
+  display: block;
+  height: 1rem;
+  overflow: hidden;
+  padding: 0;
+  width: 100%;
+}
+
+.progress::-webkit-progress-bar {
+  background-color: #ededed;
+}
+
+.progress::-webkit-progress-value {
+  background-color: #4a4a4a;
+}
+
+.progress::-moz-progress-bar {
+  background-color: #4a4a4a;
+}
+
+.progress::-ms-fill {
+  background-color: #4a4a4a;
+  border: none;
+}
+
+.progress.is-white::-webkit-progress-value {
+  background-color: #fff;
+}
+
+.progress.is-white::-moz-progress-bar {
+  background-color: #fff;
+}
+
+.progress.is-white::-ms-fill {
+  background-color: #fff;
+}
+
+.progress.is-white:indeterminate {
+  background-image: linear-gradient(to right, #fff 30%, #ededed 30%);
+}
+
+.progress.is-black::-webkit-progress-value {
+  background-color: #0a0a0a;
+}
+
+.progress.is-black::-moz-progress-bar {
+  background-color: #0a0a0a;
+}
+
+.progress.is-black::-ms-fill {
+  background-color: #0a0a0a;
+}
+
+.progress.is-black:indeterminate {
+  background-image: linear-gradient(to right, #0a0a0a 30%, #ededed 30%);
+}
+
+.progress.is-light::-webkit-progress-value {
+  background-color: #f5f5f5;
+}
+
+.progress.is-light::-moz-progress-bar {
+  background-color: #f5f5f5;
+}
+
+.progress.is-light::-ms-fill {
+  background-color: #f5f5f5;
+}
+
+.progress.is-light:indeterminate {
+  background-image: linear-gradient(to right, #f5f5f5 30%, #ededed 30%);
+}
+
+.progress.is-dark::-webkit-progress-value {
+  background-color: #363636;
+}
+
+.progress.is-dark::-moz-progress-bar {
+  background-color: #363636;
+}
+
+.progress.is-dark::-ms-fill {
+  background-color: #363636;
+}
+
+.progress.is-dark:indeterminate {
+  background-image: linear-gradient(to right, #363636 30%, #ededed 30%);
+}
+
+.progress.is-primary::-webkit-progress-value {
+  background-color: #00d1b2;
+}
+
+.progress.is-primary::-moz-progress-bar {
+  background-color: #00d1b2;
+}
+
+.progress.is-primary::-ms-fill {
+  background-color: #00d1b2;
+}
+
+.progress.is-primary:indeterminate {
+  background-image: linear-gradient(to right, #00d1b2 30%, #ededed 30%);
+}
+
+.progress.is-link::-webkit-progress-value {
+  background-color: #485fc7;
+}
+
+.progress.is-link::-moz-progress-bar {
+  background-color: #485fc7;
+}
+
+.progress.is-link::-ms-fill {
+  background-color: #485fc7;
+}
+
+.progress.is-link:indeterminate {
+  background-image: linear-gradient(to right, #485fc7 30%, #ededed 30%);
+}
+
+.progress.is-info::-webkit-progress-value {
+  background-color: #3e8ed0;
+}
+
+.progress.is-info::-moz-progress-bar {
+  background-color: #3e8ed0;
+}
+
+.progress.is-info::-ms-fill {
+  background-color: #3e8ed0;
+}
+
+.progress.is-info:indeterminate {
+  background-image: linear-gradient(to right, #3e8ed0 30%, #ededed 30%);
+}
+
+.progress.is-success::-webkit-progress-value {
+  background-color: #48c78e;
+}
+
+.progress.is-success::-moz-progress-bar {
+  background-color: #48c78e;
+}
+
+.progress.is-success::-ms-fill {
+  background-color: #48c78e;
+}
+
+.progress.is-success:indeterminate {
+  background-image: linear-gradient(to right, #48c78e 30%, #ededed 30%);
+}
+
+.progress.is-warning::-webkit-progress-value {
+  background-color: #ffe08a;
+}
+
+.progress.is-warning::-moz-progress-bar {
+  background-color: #ffe08a;
+}
+
+.progress.is-warning::-ms-fill {
+  background-color: #ffe08a;
+}
+
+.progress.is-warning:indeterminate {
+  background-image: linear-gradient(to right, #ffe08a 30%, #ededed 30%);
+}
+
+.progress.is-danger::-webkit-progress-value {
+  background-color: #f14668;
+}
+
+.progress.is-danger::-moz-progress-bar {
+  background-color: #f14668;
+}
+
+.progress.is-danger::-ms-fill {
+  background-color: #f14668;
+}
+
+.progress.is-danger:indeterminate {
+  background-image: linear-gradient(to right, #f14668 30%, #ededed 30%);
+}
+
+.progress:indeterminate {
+  -webkit-animation-duration: 1.5s;
+  animation-duration: 1.5s;
+  -webkit-animation-iteration-count: infinite;
+  animation-iteration-count: infinite;
+  -webkit-animation-name: moveIndeterminate;
+  animation-name: moveIndeterminate;
+  -webkit-animation-timing-function: linear;
+  animation-timing-function: linear;
+  background-color: #ededed;
+  background-image: linear-gradient(to right, #4a4a4a 30%, #ededed 30%);
+  background-position: top left;
+  background-repeat: no-repeat;
+  background-size: 150% 150%;
+}
+
+.progress:indeterminate::-webkit-progress-bar {
+  background-color: transparent;
+}
+
+.progress:indeterminate::-moz-progress-bar {
+  background-color: transparent;
+}
+
+.progress:indeterminate::-ms-fill {
+  animation-name: none;
+}
+
+.progress.is-small {
+  height: 0.75rem;
+}
+
+.progress.is-medium {
+  height: 1.25rem;
+}
+
+.progress.is-large {
+  height: 1.5rem;
+}
+
+@-webkit-keyframes moveIndeterminate {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+
+@keyframes moveIndeterminate {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+
+.table {
+  background-color: #fff;
+  color: #363636;
+}
+
+.table td,
+.table th {
+  border: 1px solid #dbdbdb;
+  border-width: 0 0 1px;
+  padding: 0.5em 0.75em;
+  vertical-align: top;
+}
+
+.table td.is-white,
+.table th.is-white {
+  background-color: #fff;
+  border-color: #fff;
+  color: #0a0a0a;
+}
+
+.table td.is-black,
+.table th.is-black {
+  background-color: #0a0a0a;
+  border-color: #0a0a0a;
+  color: #fff;
+}
+
+.table td.is-light,
+.table th.is-light {
+  background-color: #f5f5f5;
+  border-color: #f5f5f5;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.table td.is-dark,
+.table th.is-dark {
+  background-color: #363636;
+  border-color: #363636;
+  color: #fff;
+}
+
+.table td.is-primary,
+.table th.is-primary {
+  background-color: #00d1b2;
+  border-color: #00d1b2;
+  color: #fff;
+}
+
+.table td.is-link,
+.table th.is-link {
+  background-color: #485fc7;
+  border-color: #485fc7;
+  color: #fff;
+}
+
+.table td.is-info,
+.table th.is-info {
+  background-color: #3e8ed0;
+  border-color: #3e8ed0;
+  color: #fff;
+}
+
+.table td.is-success,
+.table th.is-success {
+  background-color: #48c78e;
+  border-color: #48c78e;
+  color: #fff;
+}
+
+.table td.is-warning,
+.table th.is-warning {
+  background-color: #ffe08a;
+  border-color: #ffe08a;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.table td.is-danger,
+.table th.is-danger {
+  background-color: #f14668;
+  border-color: #f14668;
+  color: #fff;
+}
+
+.table td.is-narrow,
+.table th.is-narrow {
+  white-space: nowrap;
+  width: 1%;
+}
+
+.table td.is-selected,
+.table th.is-selected {
+  background-color: #00d1b2;
+  color: #fff;
+}
+
+.table td.is-selected a,
+.table td.is-selected strong,
+.table th.is-selected a,
+.table th.is-selected strong {
+  color: currentColor;
+}
+
+.table td.is-vcentered,
+.table th.is-vcentered {
+  vertical-align: middle;
+}
+
+.table th {
+  color: #363636;
+}
+
+.table th:not([align]) {
+  text-align: left;
+}
+
+.table tr.is-selected {
+  background-color: #00d1b2;
+  color: #fff;
+}
+
+.table tr.is-selected a,
+.table tr.is-selected strong {
+  color: currentColor;
+}
+
+.table tr.is-selected td,
+.table tr.is-selected th {
+  border-color: #fff;
+  color: currentColor;
+}
+
+.table thead {
+  background-color: transparent;
+}
+
+.table thead td,
+.table thead th {
+  border-width: 0 0 2px;
+  color: #363636;
+}
+
+.table tfoot {
+  background-color: transparent;
+}
+
+.table tfoot td,
+.table tfoot th {
+  border-width: 2px 0 0;
+  color: #363636;
+}
+
+.table tbody {
+  background-color: transparent;
+}
+
+.table tbody tr:last-child td,
+.table tbody tr:last-child th {
+  border-bottom-width: 0;
+}
+
+.table.is-bordered td,
+.table.is-bordered th {
+  border-width: 1px;
+}
+
+.table.is-bordered tr:last-child td,
+.table.is-bordered tr:last-child th {
+  border-bottom-width: 1px;
+}
+
+.table.is-fullwidth {
+  width: 100%;
+}
+
+.table.is-hoverable tbody tr:not(.is-selected):hover {
+  background-color: #fafafa;
+}
+
+.table.is-hoverable.is-striped tbody tr:not(.is-selected):hover {
+  background-color: #fafafa;
+}
+
+.table.is-hoverable.is-striped tbody tr:not(.is-selected):hover:nth-child(2n) {
+  background-color: #f5f5f5;
+}
+
+.table.is-narrow td,
+.table.is-narrow th {
+  padding: 0.25em 0.5em;
+}
+
+.table.is-striped tbody tr:not(.is-selected):nth-child(2n) {
+  background-color: #fafafa;
+}
+
+.table-container {
+  -webkit-overflow-scrolling: touch;
+  overflow: auto;
+  overflow-y: hidden;
+  max-width: 100%;
+}
+
+.tags {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+.tags .tag {
+  margin-bottom: 0.5rem;
+}
+
+.tags .tag:not(:last-child) {
+  margin-right: 0.5rem;
+}
+
+.tags:last-child {
+  margin-bottom: -0.5rem;
+}
+
+.tags:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+.tags.are-medium .tag:not(.is-normal):not(.is-large) {
+  font-size: 1rem;
+}
+
+.tags.are-large .tag:not(.is-normal):not(.is-medium) {
+  font-size: 1.25rem;
+}
+
+.tags.is-centered {
+  justify-content: center;
+}
+
+.tags.is-centered .tag {
+  margin-right: 0.25rem;
+  margin-left: 0.25rem;
+}
+
+.tags.is-right {
+  justify-content: flex-end;
+}
+
+.tags.is-right .tag:not(:first-child) {
+  margin-left: 0.5rem;
+}
+
+.tags.is-right .tag:not(:last-child) {
+  margin-right: 0;
+}
+
+.tags.has-addons .tag {
+  margin-right: 0;
+}
+
+.tags.has-addons .tag:not(:first-child) {
+  margin-left: 0;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.tags.has-addons .tag:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.tag:not(body) {
+  align-items: center;
+  background-color: #f5f5f5;
+  border-radius: 4px;
+  color: #4a4a4a;
+  display: inline-flex;
+  font-size: 0.75rem;
+  height: 2em;
+  justify-content: center;
+  line-height: 1.5;
+  padding-left: 0.75em;
+  padding-right: 0.75em;
+  white-space: nowrap;
+}
+
+.tag:not(body) .delete {
+  margin-left: 0.25rem;
+  margin-right: -0.375rem;
+}
+
+.tag:not(body).is-white {
+  background-color: #fff;
+  color: #0a0a0a;
+}
+
+.tag:not(body).is-black {
+  background-color: #0a0a0a;
+  color: #fff;
+}
+
+.tag:not(body).is-light {
+  background-color: #f5f5f5;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.tag:not(body).is-dark {
+  background-color: #363636;
+  color: #fff;
+}
+
+.tag:not(body).is-primary {
+  background-color: #00d1b2;
+  color: #fff;
+}
+
+.tag:not(body).is-primary.is-light {
+  background-color: #ebfffc;
+  color: #00947e;
+}
+
+.tag:not(body).is-link {
+  background-color: #485fc7;
+  color: #fff;
+}
+
+.tag:not(body).is-link.is-light {
+  background-color: #eff1fa;
+  color: #3850b7;
+}
+
+.tag:not(body).is-info {
+  background-color: #3e8ed0;
+  color: #fff;
+}
+
+.tag:not(body).is-info.is-light {
+  background-color: #eff5fb;
+  color: #296fa8;
+}
+
+.tag:not(body).is-success {
+  background-color: #48c78e;
+  color: #fff;
+}
+
+.tag:not(body).is-success.is-light {
+  background-color: #effaf5;
+  color: #257953;
+}
+
+.tag:not(body).is-warning {
+  background-color: #ffe08a;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.tag:not(body).is-warning.is-light {
+  background-color: #fffaeb;
+  color: #946c00;
+}
+
+.tag:not(body).is-danger {
+  background-color: #f14668;
+  color: #fff;
+}
+
+.tag:not(body).is-danger.is-light {
+  background-color: #feecf0;
+  color: #cc0f35;
+}
+
+.tag:not(body).is-normal {
+  font-size: 0.75rem;
+}
+
+.tag:not(body).is-medium {
+  font-size: 1rem;
+}
+
+.tag:not(body).is-large {
+  font-size: 1.25rem;
+}
+
+.tag:not(body) .icon:first-child:not(:last-child) {
+  margin-left: -0.375em;
+  margin-right: 0.1875em;
+}
+
+.tag:not(body) .icon:last-child:not(:first-child) {
+  margin-left: 0.1875em;
+  margin-right: -0.375em;
+}
+
+.tag:not(body) .icon:first-child:last-child {
+  margin-left: -0.375em;
+  margin-right: -0.375em;
+}
+
+.tag:not(body).is-delete {
+  margin-left: 1px;
+  padding: 0;
+  position: relative;
+  width: 2em;
+}
+
+.tag:not(body).is-delete::after,
+.tag:not(body).is-delete::before {
+  background-color: currentColor;
+  content: "";
+  display: block;
+  left: 50%;
+  position: absolute;
+  top: 50%;
+  transform: translateX(-50%) translateY(-50%) rotate(45deg);
+  transform-origin: center center;
+}
+
+.tag:not(body).is-delete::before {
+  height: 1px;
+  width: 50%;
+}
+
+.tag:not(body).is-delete::after {
+  height: 50%;
+  width: 1px;
+}
+
+.tag:not(body).is-delete:focus,
+.tag:not(body).is-delete:hover {
+  background-color: #e8e8e8;
+}
+
+.tag:not(body).is-delete:active {
+  background-color: #dbdbdb;
+}
+
+.tag:not(body).is-rounded {
+  border-radius: 9999px;
+}
+
+a.tag:hover {
+  text-decoration: underline;
+}
+
+.subtitle,
+.title {
+  word-break: break-word;
+}
+
+.subtitle em,
+.subtitle span,
+.title em,
+.title span {
+  font-weight: inherit;
+}
+
+.subtitle sub,
+.title sub {
+  font-size: 0.75em;
+}
+
+.subtitle sup,
+.title sup {
+  font-size: 0.75em;
+}
+
+.subtitle .tag,
+.title .tag {
+  vertical-align: middle;
+}
+
+.title {
+  color: #363636;
+  font-size: 2rem;
+  font-weight: 600;
+  line-height: 1.125;
+}
+
+.title strong {
+  color: inherit;
+  font-weight: inherit;
+}
+
+.title:not(.is-spaced) + .subtitle {
+  margin-top: -1.25rem;
+}
+
+.title.is-1 {
+  font-size: 3rem;
+}
+
+.title.is-2 {
+  font-size: 2.5rem;
+}
+
+.title.is-3 {
+  font-size: 2rem;
+}
+
+.title.is-4 {
+  font-size: 1.5rem;
+}
+
+.title.is-5 {
+  font-size: 1.25rem;
+}
+
+.title.is-6 {
+  font-size: 1rem;
+}
+
+.title.is-7 {
+  font-size: 0.75rem;
+}
+
+.subtitle {
+  color: #4a4a4a;
+  font-size: 1.25rem;
+  font-weight: 400;
+  line-height: 1.25;
+}
+
+.subtitle strong {
+  color: #363636;
+  font-weight: 600;
+}
+
+.subtitle:not(.is-spaced) + .title {
+  margin-top: -1.25rem;
+}
+
+.subtitle.is-1 {
+  font-size: 3rem;
+}
+
+.subtitle.is-2 {
+  font-size: 2.5rem;
+}
+
+.subtitle.is-3 {
+  font-size: 2rem;
+}
+
+.subtitle.is-4 {
+  font-size: 1.5rem;
+}
+
+.subtitle.is-5 {
+  font-size: 1.25rem;
+}
+
+.subtitle.is-6 {
+  font-size: 1rem;
+}
+
+.subtitle.is-7 {
+  font-size: 0.75rem;
+}
+
+.heading {
+  display: block;
+  font-size: 11px;
+  letter-spacing: 1px;
+  margin-bottom: 5px;
+  text-transform: uppercase;
+}
+
+.number {
+  align-items: center;
+  background-color: #f5f5f5;
+  border-radius: 9999px;
+  display: inline-flex;
+  font-size: 1.25rem;
+  height: 2em;
+  justify-content: center;
+  margin-right: 1.5rem;
+  min-width: 2.5em;
+  padding: 0.25rem 0.5rem;
+  text-align: center;
+  vertical-align: top;
+}
+
+.input,
+.select select,
+.textarea {
+  background-color: #fff;
+  border-color: #dbdbdb;
+  border-radius: 4px;
+  color: #363636;
+}
+
+.input::-moz-placeholder,
+.select select::-moz-placeholder,
+.textarea::-moz-placeholder {
+  color: rgba(54, 54, 54, 0.3);
+}
+
+.input::-webkit-input-placeholder,
+.select select::-webkit-input-placeholder,
+.textarea::-webkit-input-placeholder {
+  color: rgba(54, 54, 54, 0.3);
+}
+
+.input:-moz-placeholder,
+.select select:-moz-placeholder,
+.textarea:-moz-placeholder {
+  color: rgba(54, 54, 54, 0.3);
+}
+
+.input:-ms-input-placeholder,
+.select select:-ms-input-placeholder,
+.textarea:-ms-input-placeholder {
+  color: rgba(54, 54, 54, 0.3);
+}
+
+.input:hover,
+.is-hovered.input,
+.is-hovered.textarea,
+.select select.is-hovered,
+.select select:hover,
+.textarea:hover {
+  border-color: #b5b5b5;
+}
+
+.input:active,
+.input:focus,
+.is-active.input,
+.is-active.textarea,
+.is-focused.input,
+.is-focused.textarea,
+.select select.is-active,
+.select select.is-focused,
+.select select:active,
+.select select:focus,
+.textarea:active,
+.textarea:focus {
+  border-color: #485fc7;
+  box-shadow: 0 0 0 0.125em rgba(72, 95, 199, 0.25);
+}
+
+.input[disabled],
+.select fieldset[disabled] select,
+.select select[disabled],
+.textarea[disabled],
+fieldset[disabled] .input,
+fieldset[disabled] .select select,
+fieldset[disabled] .textarea {
+  background-color: #f5f5f5;
+  border-color: #f5f5f5;
+  box-shadow: none;
+  color: #7a7a7a;
+}
+
+.input[disabled]::-moz-placeholder,
+.select fieldset[disabled] select::-moz-placeholder,
+.select select[disabled]::-moz-placeholder,
+.textarea[disabled]::-moz-placeholder,
+fieldset[disabled] .input::-moz-placeholder,
+fieldset[disabled] .select select::-moz-placeholder,
+fieldset[disabled] .textarea::-moz-placeholder {
+  color: rgba(122, 122, 122, 0.3);
+}
+
+.input[disabled]::-webkit-input-placeholder,
+.select fieldset[disabled] select::-webkit-input-placeholder,
+.select select[disabled]::-webkit-input-placeholder,
+.textarea[disabled]::-webkit-input-placeholder,
+fieldset[disabled] .input::-webkit-input-placeholder,
+fieldset[disabled] .select select::-webkit-input-placeholder,
+fieldset[disabled] .textarea::-webkit-input-placeholder {
+  color: rgba(122, 122, 122, 0.3);
+}
+
+.input[disabled]:-moz-placeholder,
+.select fieldset[disabled] select:-moz-placeholder,
+.select select[disabled]:-moz-placeholder,
+.textarea[disabled]:-moz-placeholder,
+fieldset[disabled] .input:-moz-placeholder,
+fieldset[disabled] .select select:-moz-placeholder,
+fieldset[disabled] .textarea:-moz-placeholder {
+  color: rgba(122, 122, 122, 0.3);
+}
+
+.input[disabled]:-ms-input-placeholder,
+.select fieldset[disabled] select:-ms-input-placeholder,
+.select select[disabled]:-ms-input-placeholder,
+.textarea[disabled]:-ms-input-placeholder,
+fieldset[disabled] .input:-ms-input-placeholder,
+fieldset[disabled] .select select:-ms-input-placeholder,
+fieldset[disabled] .textarea:-ms-input-placeholder {
+  color: rgba(122, 122, 122, 0.3);
+}
+
+.input,
+.textarea {
+  box-shadow: inset 0 0.0625em 0.125em rgba(10, 10, 10, 0.05);
+  max-width: 100%;
+  width: 100%;
+}
+
+.input[readonly],
+.textarea[readonly] {
+  box-shadow: none;
+}
+
+.is-white.input,
+.is-white.textarea {
+  border-color: #fff;
+}
+
+.is-white.input:active,
+.is-white.input:focus,
+.is-white.is-active.input,
+.is-white.is-active.textarea,
+.is-white.is-focused.input,
+.is-white.is-focused.textarea,
+.is-white.textarea:active,
+.is-white.textarea:focus {
+  box-shadow: 0 0 0 0.125em rgba(255, 255, 255, 0.25);
+}
+
+.is-black.input,
+.is-black.textarea {
+  border-color: #0a0a0a;
+}
+
+.is-black.input:active,
+.is-black.input:focus,
+.is-black.is-active.input,
+.is-black.is-active.textarea,
+.is-black.is-focused.input,
+.is-black.is-focused.textarea,
+.is-black.textarea:active,
+.is-black.textarea:focus {
+  box-shadow: 0 0 0 0.125em rgba(10, 10, 10, 0.25);
+}
+
+.is-light.input,
+.is-light.textarea {
+  border-color: #f5f5f5;
+}
+
+.is-light.input:active,
+.is-light.input:focus,
+.is-light.is-active.input,
+.is-light.is-active.textarea,
+.is-light.is-focused.input,
+.is-light.is-focused.textarea,
+.is-light.textarea:active,
+.is-light.textarea:focus {
+  box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25);
+}
+
+.is-dark.input,
+.is-dark.textarea {
+  border-color: #363636;
+}
+
+.is-dark.input:active,
+.is-dark.input:focus,
+.is-dark.is-active.input,
+.is-dark.is-active.textarea,
+.is-dark.is-focused.input,
+.is-dark.is-focused.textarea,
+.is-dark.textarea:active,
+.is-dark.textarea:focus {
+  box-shadow: 0 0 0 0.125em rgba(54, 54, 54, 0.25);
+}
+
+.is-primary.input,
+.is-primary.textarea {
+  border-color: #00d1b2;
+}
+
+.is-primary.input:active,
+.is-primary.input:focus,
+.is-primary.is-active.input,
+.is-primary.is-active.textarea,
+.is-primary.is-focused.input,
+.is-primary.is-focused.textarea,
+.is-primary.textarea:active,
+.is-primary.textarea:focus {
+  box-shadow: 0 0 0 0.125em rgba(0, 209, 178, 0.25);
+}
+
+.is-link.input,
+.is-link.textarea {
+  border-color: #485fc7;
+}
+
+.is-link.input:active,
+.is-link.input:focus,
+.is-link.is-active.input,
+.is-link.is-active.textarea,
+.is-link.is-focused.input,
+.is-link.is-focused.textarea,
+.is-link.textarea:active,
+.is-link.textarea:focus {
+  box-shadow: 0 0 0 0.125em rgba(72, 95, 199, 0.25);
+}
+
+.is-info.input,
+.is-info.textarea {
+  border-color: #3e8ed0;
+}
+
+.is-info.input:active,
+.is-info.input:focus,
+.is-info.is-active.input,
+.is-info.is-active.textarea,
+.is-info.is-focused.input,
+.is-info.is-focused.textarea,
+.is-info.textarea:active,
+.is-info.textarea:focus {
+  box-shadow: 0 0 0 0.125em rgba(62, 142, 208, 0.25);
+}
+
+.is-success.input,
+.is-success.textarea {
+  border-color: #48c78e;
+}
+
+.is-success.input:active,
+.is-success.input:focus,
+.is-success.is-active.input,
+.is-success.is-active.textarea,
+.is-success.is-focused.input,
+.is-success.is-focused.textarea,
+.is-success.textarea:active,
+.is-success.textarea:focus {
+  box-shadow: 0 0 0 0.125em rgba(72, 199, 142, 0.25);
+}
+
+.is-warning.input,
+.is-warning.textarea {
+  border-color: #ffe08a;
+}
+
+.is-warning.input:active,
+.is-warning.input:focus,
+.is-warning.is-active.input,
+.is-warning.is-active.textarea,
+.is-warning.is-focused.input,
+.is-warning.is-focused.textarea,
+.is-warning.textarea:active,
+.is-warning.textarea:focus {
+  box-shadow: 0 0 0 0.125em rgba(255, 224, 138, 0.25);
+}
+
+.is-danger.input,
+.is-danger.textarea {
+  border-color: #f14668;
+}
+
+.is-danger.input:active,
+.is-danger.input:focus,
+.is-danger.is-active.input,
+.is-danger.is-active.textarea,
+.is-danger.is-focused.input,
+.is-danger.is-focused.textarea,
+.is-danger.textarea:active,
+.is-danger.textarea:focus {
+  box-shadow: 0 0 0 0.125em rgba(241, 70, 104, 0.25);
+}
+
+.is-small.input,
+.is-small.textarea {
+  border-radius: 2px;
+  font-size: 0.75rem;
+}
+
+.is-medium.input,
+.is-medium.textarea {
+  font-size: 1.25rem;
+}
+
+.is-large.input,
+.is-large.textarea {
+  font-size: 1.5rem;
+}
+
+.is-fullwidth.input,
+.is-fullwidth.textarea {
+  display: block;
+  width: 100%;
+}
+
+.is-inline.input,
+.is-inline.textarea {
+  display: inline;
+  width: auto;
+}
+
+.input.is-rounded {
+  border-radius: 9999px;
+  padding-left: calc(calc(0.75em - 1px) + 0.375em);
+  padding-right: calc(calc(0.75em - 1px) + 0.375em);
+}
+
+.input.is-static {
+  background-color: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.textarea {
+  display: block;
+  max-width: 100%;
+  min-width: 100%;
+  padding: calc(0.75em - 1px);
+  resize: vertical;
+}
+
+.textarea:not([rows]) {
+  max-height: 40em;
+  min-height: 8em;
+}
+
+.textarea[rows] {
+  height: initial;
+}
+
+.textarea.has-fixed-size {
+  resize: none;
+}
+
+.checkbox,
+.radio {
+  cursor: pointer;
+  display: inline-block;
+  line-height: 1.25;
+  position: relative;
+}
+
+.checkbox input,
+.radio input {
+  cursor: pointer;
+}
+
+.checkbox:hover,
+.radio:hover {
+  color: #363636;
+}
+
+.checkbox input[disabled],
+.checkbox[disabled],
+.radio input[disabled],
+.radio[disabled],
+fieldset[disabled] .checkbox,
+fieldset[disabled] .radio {
+  color: #7a7a7a;
+  cursor: not-allowed;
+}
+
+.radio + .radio {
+  margin-left: 0.5em;
+}
+
+.select {
+  display: inline-block;
+  max-width: 100%;
+  position: relative;
+  vertical-align: top;
+}
+
+.select:not(.is-multiple) {
+  height: 2.5em;
+}
+
+.select:not(.is-multiple):not(.is-loading)::after {
+  border-color: #485fc7;
+  right: 1.125em;
+  z-index: 4;
+}
+
+.select.is-rounded select {
+  border-radius: 9999px;
+  padding-left: 1em;
+}
+
+.select select {
+  cursor: pointer;
+  display: block;
+  font-size: 1em;
+  max-width: 100%;
+  outline: 0;
+}
+
+.select select::-ms-expand {
+  display: none;
+}
+
+.select select[disabled]:hover,
+fieldset[disabled] .select select:hover {
+  border-color: #f5f5f5;
+}
+
+.select select:not([multiple]) {
+  padding-right: 2.5em;
+}
+
+.select select[multiple] {
+  height: auto;
+  padding: 0;
+}
+
+.select select[multiple] option {
+  padding: 0.5em 1em;
+}
+
+.select:not(.is-multiple):not(.is-loading):hover::after {
+  border-color: #363636;
+}
+
+.select.is-white:not(:hover)::after {
+  border-color: #fff;
+}
+
+.select.is-white select {
+  border-color: #fff;
+}
+
+.select.is-white select.is-hovered,
+.select.is-white select:hover {
+  border-color: #f2f2f2;
+}
+
+.select.is-white select.is-active,
+.select.is-white select.is-focused,
+.select.is-white select:active,
+.select.is-white select:focus {
+  box-shadow: 0 0 0 0.125em rgba(255, 255, 255, 0.25);
+}
+
+.select.is-black:not(:hover)::after {
+  border-color: #0a0a0a;
+}
+
+.select.is-black select {
+  border-color: #0a0a0a;
+}
+
+.select.is-black select.is-hovered,
+.select.is-black select:hover {
+  border-color: #000;
+}
+
+.select.is-black select.is-active,
+.select.is-black select.is-focused,
+.select.is-black select:active,
+.select.is-black select:focus {
+  box-shadow: 0 0 0 0.125em rgba(10, 10, 10, 0.25);
+}
+
+.select.is-light:not(:hover)::after {
+  border-color: #f5f5f5;
+}
+
+.select.is-light select {
+  border-color: #f5f5f5;
+}
+
+.select.is-light select.is-hovered,
+.select.is-light select:hover {
+  border-color: #e8e8e8;
+}
+
+.select.is-light select.is-active,
+.select.is-light select.is-focused,
+.select.is-light select:active,
+.select.is-light select:focus {
+  box-shadow: 0 0 0 0.125em rgba(245, 245, 245, 0.25);
+}
+
+.select.is-dark:not(:hover)::after {
+  border-color: #363636;
+}
+
+.select.is-dark select {
+  border-color: #363636;
+}
+
+.select.is-dark select.is-hovered,
+.select.is-dark select:hover {
+  border-color: #292929;
+}
+
+.select.is-dark select.is-active,
+.select.is-dark select.is-focused,
+.select.is-dark select:active,
+.select.is-dark select:focus {
+  box-shadow: 0 0 0 0.125em rgba(54, 54, 54, 0.25);
+}
+
+.select.is-primary:not(:hover)::after {
+  border-color: #00d1b2;
+}
+
+.select.is-primary select {
+  border-color: #00d1b2;
+}
+
+.select.is-primary select.is-hovered,
+.select.is-primary select:hover {
+  border-color: #00b89c;
+}
+
+.select.is-primary select.is-active,
+.select.is-primary select.is-focused,
+.select.is-primary select:active,
+.select.is-primary select:focus {
+  box-shadow: 0 0 0 0.125em rgba(0, 209, 178, 0.25);
+}
+
+.select.is-link:not(:hover)::after {
+  border-color: #485fc7;
+}
+
+.select.is-link select {
+  border-color: #485fc7;
+}
+
+.select.is-link select.is-hovered,
+.select.is-link select:hover {
+  border-color: #3a51bb;
+}
+
+.select.is-link select.is-active,
+.select.is-link select.is-focused,
+.select.is-link select:active,
+.select.is-link select:focus {
+  box-shadow: 0 0 0 0.125em rgba(72, 95, 199, 0.25);
+}
+
+.select.is-info:not(:hover)::after {
+  border-color: #3e8ed0;
+}
+
+.select.is-info select {
+  border-color: #3e8ed0;
+}
+
+.select.is-info select.is-hovered,
+.select.is-info select:hover {
+  border-color: #3082c5;
+}
+
+.select.is-info select.is-active,
+.select.is-info select.is-focused,
+.select.is-info select:active,
+.select.is-info select:focus {
+  box-shadow: 0 0 0 0.125em rgba(62, 142, 208, 0.25);
+}
+
+.select.is-success:not(:hover)::after {
+  border-color: #48c78e;
+}
+
+.select.is-success select {
+  border-color: #48c78e;
+}
+
+.select.is-success select.is-hovered,
+.select.is-success select:hover {
+  border-color: #3abb81;
+}
+
+.select.is-success select.is-active,
+.select.is-success select.is-focused,
+.select.is-success select:active,
+.select.is-success select:focus {
+  box-shadow: 0 0 0 0.125em rgba(72, 199, 142, 0.25);
+}
+
+.select.is-warning:not(:hover)::after {
+  border-color: #ffe08a;
+}
+
+.select.is-warning select {
+  border-color: #ffe08a;
+}
+
+.select.is-warning select.is-hovered,
+.select.is-warning select:hover {
+  border-color: #ffd970;
+}
+
+.select.is-warning select.is-active,
+.select.is-warning select.is-focused,
+.select.is-warning select:active,
+.select.is-warning select:focus {
+  box-shadow: 0 0 0 0.125em rgba(255, 224, 138, 0.25);
+}
+
+.select.is-danger:not(:hover)::after {
+  border-color: #f14668;
+}
+
+.select.is-danger select {
+  border-color: #f14668;
+}
+
+.select.is-danger select.is-hovered,
+.select.is-danger select:hover {
+  border-color: #ef2e55;
+}
+
+.select.is-danger select.is-active,
+.select.is-danger select.is-focused,
+.select.is-danger select:active,
+.select.is-danger select:focus {
+  box-shadow: 0 0 0 0.125em rgba(241, 70, 104, 0.25);
+}
+
+.select.is-small {
+  border-radius: 2px;
+  font-size: 0.75rem;
+}
+
+.select.is-medium {
+  font-size: 1.25rem;
+}
+
+.select.is-large {
+  font-size: 1.5rem;
+}
+
+.select.is-disabled::after {
+  border-color: #7a7a7a !important;
+  opacity: 0.5;
+}
+
+.select.is-fullwidth {
+  width: 100%;
+}
+
+.select.is-fullwidth select {
+  width: 100%;
+}
+
+.select.is-loading::after {
+  margin-top: 0;
+  position: absolute;
+  right: 0.625em;
+  top: 0.625em;
+  transform: none;
+}
+
+.select.is-loading.is-small:after {
+  font-size: 0.75rem;
+}
+
+.select.is-loading.is-medium:after {
+  font-size: 1.25rem;
+}
+
+.select.is-loading.is-large:after {
+  font-size: 1.5rem;
+}
+
+.file {
+  align-items: stretch;
+  display: flex;
+  justify-content: flex-start;
+  position: relative;
+}
+
+.file.is-white .file-cta {
+  background-color: #fff;
+  border-color: transparent;
+  color: #0a0a0a;
+}
+
+.file.is-white.is-hovered .file-cta,
+.file.is-white:hover .file-cta {
+  background-color: #f9f9f9;
+  border-color: transparent;
+  color: #0a0a0a;
+}
+
+.file.is-white.is-focused .file-cta,
+.file.is-white:focus .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(255, 255, 255, 0.25);
+  color: #0a0a0a;
+}
+
+.file.is-white.is-active .file-cta,
+.file.is-white:active .file-cta {
+  background-color: #f2f2f2;
+  border-color: transparent;
+  color: #0a0a0a;
+}
+
+.file.is-black .file-cta {
+  background-color: #0a0a0a;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-black.is-hovered .file-cta,
+.file.is-black:hover .file-cta {
+  background-color: #040404;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-black.is-focused .file-cta,
+.file.is-black:focus .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(10, 10, 10, 0.25);
+  color: #fff;
+}
+
+.file.is-black.is-active .file-cta,
+.file.is-black:active .file-cta {
+  background-color: #000;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-light .file-cta {
+  background-color: #f5f5f5;
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.file.is-light.is-hovered .file-cta,
+.file.is-light:hover .file-cta {
+  background-color: #eee;
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.file.is-light.is-focused .file-cta,
+.file.is-light:focus .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(245, 245, 245, 0.25);
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.file.is-light.is-active .file-cta,
+.file.is-light:active .file-cta {
+  background-color: #e8e8e8;
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.file.is-dark .file-cta {
+  background-color: #363636;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-dark.is-hovered .file-cta,
+.file.is-dark:hover .file-cta {
+  background-color: #2f2f2f;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-dark.is-focused .file-cta,
+.file.is-dark:focus .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(54, 54, 54, 0.25);
+  color: #fff;
+}
+
+.file.is-dark.is-active .file-cta,
+.file.is-dark:active .file-cta {
+  background-color: #292929;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-primary .file-cta {
+  background-color: #00d1b2;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-primary.is-hovered .file-cta,
+.file.is-primary:hover .file-cta {
+  background-color: #00c4a7;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-primary.is-focused .file-cta,
+.file.is-primary:focus .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(0, 209, 178, 0.25);
+  color: #fff;
+}
+
+.file.is-primary.is-active .file-cta,
+.file.is-primary:active .file-cta {
+  background-color: #00b89c;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-link .file-cta {
+  background-color: #485fc7;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-link.is-hovered .file-cta,
+.file.is-link:hover .file-cta {
+  background-color: #3e56c4;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-link.is-focused .file-cta,
+.file.is-link:focus .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(72, 95, 199, 0.25);
+  color: #fff;
+}
+
+.file.is-link.is-active .file-cta,
+.file.is-link:active .file-cta {
+  background-color: #3a51bb;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-info .file-cta {
+  background-color: #3e8ed0;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-info.is-hovered .file-cta,
+.file.is-info:hover .file-cta {
+  background-color: #3488ce;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-info.is-focused .file-cta,
+.file.is-info:focus .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(62, 142, 208, 0.25);
+  color: #fff;
+}
+
+.file.is-info.is-active .file-cta,
+.file.is-info:active .file-cta {
+  background-color: #3082c5;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-success .file-cta {
+  background-color: #48c78e;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-success.is-hovered .file-cta,
+.file.is-success:hover .file-cta {
+  background-color: #3ec487;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-success.is-focused .file-cta,
+.file.is-success:focus .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(72, 199, 142, 0.25);
+  color: #fff;
+}
+
+.file.is-success.is-active .file-cta,
+.file.is-success:active .file-cta {
+  background-color: #3abb81;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-warning .file-cta {
+  background-color: #ffe08a;
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.file.is-warning.is-hovered .file-cta,
+.file.is-warning:hover .file-cta {
+  background-color: #ffdc7d;
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.file.is-warning.is-focused .file-cta,
+.file.is-warning:focus .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(255, 224, 138, 0.25);
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.file.is-warning.is-active .file-cta,
+.file.is-warning:active .file-cta {
+  background-color: #ffd970;
+  border-color: transparent;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.file.is-danger .file-cta {
+  background-color: #f14668;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-danger.is-hovered .file-cta,
+.file.is-danger:hover .file-cta {
+  background-color: #f03a5f;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-danger.is-focused .file-cta,
+.file.is-danger:focus .file-cta {
+  border-color: transparent;
+  box-shadow: 0 0 0.5em rgba(241, 70, 104, 0.25);
+  color: #fff;
+}
+
+.file.is-danger.is-active .file-cta,
+.file.is-danger:active .file-cta {
+  background-color: #ef2e55;
+  border-color: transparent;
+  color: #fff;
+}
+
+.file.is-small {
+  font-size: 0.75rem;
+}
+
+.file.is-normal {
+  font-size: 1rem;
+}
+
+.file.is-medium {
+  font-size: 1.25rem;
+}
+
+.file.is-medium .file-icon .fa {
+  font-size: 21px;
+}
+
+.file.is-large {
+  font-size: 1.5rem;
+}
+
+.file.is-large .file-icon .fa {
+  font-size: 28px;
+}
+
+.file.has-name .file-cta {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.file.has-name .file-name {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.file.has-name.is-empty .file-cta {
+  border-radius: 4px;
+}
+
+.file.has-name.is-empty .file-name {
+  display: none;
+}
+
+.file.is-boxed .file-label {
+  flex-direction: column;
+}
+
+.file.is-boxed .file-cta {
+  flex-direction: column;
+  height: auto;
+  padding: 1em 3em;
+}
+
+.file.is-boxed .file-name {
+  border-width: 0 1px 1px;
+}
+
+.file.is-boxed .file-icon {
+  height: 1.5em;
+  width: 1.5em;
+}
+
+.file.is-boxed .file-icon .fa {
+  font-size: 21px;
+}
+
+.file.is-boxed.is-small .file-icon .fa {
+  font-size: 14px;
+}
+
+.file.is-boxed.is-medium .file-icon .fa {
+  font-size: 28px;
+}
+
+.file.is-boxed.is-large .file-icon .fa {
+  font-size: 35px;
+}
+
+.file.is-boxed.has-name .file-cta {
+  border-radius: 4px 4px 0 0;
+}
+
+.file.is-boxed.has-name .file-name {
+  border-radius: 0 0 4px 4px;
+  border-width: 0 1px 1px;
+}
+
+.file.is-centered {
+  justify-content: center;
+}
+
+.file.is-fullwidth .file-label {
+  width: 100%;
+}
+
+.file.is-fullwidth .file-name {
+  flex-grow: 1;
+  max-width: none;
+}
+
+.file.is-right {
+  justify-content: flex-end;
+}
+
+.file.is-right .file-cta {
+  border-radius: 0 4px 4px 0;
+}
+
+.file.is-right .file-name {
+  border-radius: 4px 0 0 4px;
+  border-width: 1px 0 1px 1px;
+  order: -1;
+}
+
+.file-label {
+  align-items: stretch;
+  display: flex;
+  cursor: pointer;
+  justify-content: flex-start;
+  overflow: hidden;
+  position: relative;
+}
+
+.file-label:hover .file-cta {
+  background-color: #eee;
+  color: #363636;
+}
+
+.file-label:hover .file-name {
+  border-color: #d5d5d5;
+}
+
+.file-label:active .file-cta {
+  background-color: #e8e8e8;
+  color: #363636;
+}
+
+.file-label:active .file-name {
+  border-color: #cfcfcf;
+}
+
+.file-input {
+  height: 100%;
+  left: 0;
+  opacity: 0;
+  outline: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+.file-cta,
+.file-name {
+  border-color: #dbdbdb;
+  border-radius: 4px;
+  font-size: 1em;
+  padding-left: 1em;
+  padding-right: 1em;
+  white-space: nowrap;
+}
+
+.file-cta {
+  background-color: #f5f5f5;
+  color: #4a4a4a;
+}
+
+.file-name {
+  border-color: #dbdbdb;
+  border-style: solid;
+  border-width: 1px 1px 1px 0;
+  display: block;
+  max-width: 16em;
+  overflow: hidden;
+  text-align: inherit;
+  text-overflow: ellipsis;
+}
+
+.file-icon {
+  align-items: center;
+  display: flex;
+  height: 1em;
+  justify-content: center;
+  margin-right: 0.5em;
+  width: 1em;
+}
+
+.file-icon .fa {
+  font-size: 14px;
+}
+
+.label {
+  color: #363636;
+  display: block;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.label:not(:last-child) {
+  margin-bottom: 0.5em;
+}
+
+.label.is-small {
+  font-size: 0.75rem;
+}
+
+.label.is-medium {
+  font-size: 1.25rem;
+}
+
+.label.is-large {
+  font-size: 1.5rem;
+}
+
+.help {
+  display: block;
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.help.is-white {
+  color: #fff;
+}
+
+.help.is-black {
+  color: #0a0a0a;
+}
+
+.help.is-light {
+  color: #f5f5f5;
+}
+
+.help.is-dark {
+  color: #363636;
+}
+
+.help.is-primary {
+  color: #00d1b2;
+}
+
+.help.is-link {
+  color: #485fc7;
+}
+
+.help.is-info {
+  color: #3e8ed0;
+}
+
+.help.is-success {
+  color: #48c78e;
+}
+
+.help.is-warning {
+  color: #ffe08a;
+}
+
+.help.is-danger {
+  color: #f14668;
+}
+
+.field:not(:last-child) {
+  margin-bottom: 0.75rem;
+}
+
+.field.has-addons {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.field.has-addons .control:not(:last-child) {
+  margin-right: -1px;
+}
+
+.field.has-addons .control:not(:first-child):not(:last-child) .button,
+.field.has-addons .control:not(:first-child):not(:last-child) .input,
+.field.has-addons .control:not(:first-child):not(:last-child) .select select {
+  border-radius: 0;
+}
+
+.field.has-addons .control:first-child:not(:only-child) .button,
+.field.has-addons .control:first-child:not(:only-child) .input,
+.field.has-addons .control:first-child:not(:only-child) .select select {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.field.has-addons .control:last-child:not(:only-child) .button,
+.field.has-addons .control:last-child:not(:only-child) .input,
+.field.has-addons .control:last-child:not(:only-child) .select select {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.field.has-addons .control .button:not([disabled]).is-hovered,
+.field.has-addons .control .button:not([disabled]):hover,
+.field.has-addons .control .input:not([disabled]).is-hovered,
+.field.has-addons .control .input:not([disabled]):hover,
+.field.has-addons .control .select select:not([disabled]).is-hovered,
+.field.has-addons .control .select select:not([disabled]):hover {
+  z-index: 2;
+}
+
+.field.has-addons .control .button:not([disabled]).is-active,
+.field.has-addons .control .button:not([disabled]).is-focused,
+.field.has-addons .control .button:not([disabled]):active,
+.field.has-addons .control .button:not([disabled]):focus,
+.field.has-addons .control .input:not([disabled]).is-active,
+.field.has-addons .control .input:not([disabled]).is-focused,
+.field.has-addons .control .input:not([disabled]):active,
+.field.has-addons .control .input:not([disabled]):focus,
+.field.has-addons .control .select select:not([disabled]).is-active,
+.field.has-addons .control .select select:not([disabled]).is-focused,
+.field.has-addons .control .select select:not([disabled]):active,
+.field.has-addons .control .select select:not([disabled]):focus {
+  z-index: 3;
+}
+
+.field.has-addons .control .button:not([disabled]).is-active:hover,
+.field.has-addons .control .button:not([disabled]).is-focused:hover,
+.field.has-addons .control .button:not([disabled]):active:hover,
+.field.has-addons .control .button:not([disabled]):focus:hover,
+.field.has-addons .control .input:not([disabled]).is-active:hover,
+.field.has-addons .control .input:not([disabled]).is-focused:hover,
+.field.has-addons .control .input:not([disabled]):active:hover,
+.field.has-addons .control .input:not([disabled]):focus:hover,
+.field.has-addons .control .select select:not([disabled]).is-active:hover,
+.field.has-addons .control .select select:not([disabled]).is-focused:hover,
+.field.has-addons .control .select select:not([disabled]):active:hover,
+.field.has-addons .control .select select:not([disabled]):focus:hover {
+  z-index: 4;
+}
+
+.field.has-addons .control.is-expanded {
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+.field.has-addons.has-addons-centered {
+  justify-content: center;
+}
+
+.field.has-addons.has-addons-right {
+  justify-content: flex-end;
+}
+
+.field.has-addons.has-addons-fullwidth .control {
+  flex-grow: 1;
+  flex-shrink: 0;
+}
+
+.field.is-grouped {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.field.is-grouped > .control {
+  flex-shrink: 0;
+}
+
+.field.is-grouped > .control:not(:last-child) {
+  margin-bottom: 0;
+  margin-right: 0.75rem;
+}
+
+.field.is-grouped > .control.is-expanded {
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+.field.is-grouped.is-grouped-centered {
+  justify-content: center;
+}
+
+.field.is-grouped.is-grouped-right {
+  justify-content: flex-end;
+}
+
+.field.is-grouped.is-grouped-multiline {
+  flex-wrap: wrap;
+}
+
+.field.is-grouped.is-grouped-multiline > .control:last-child,
+.field.is-grouped.is-grouped-multiline > .control:not(:last-child) {
+  margin-bottom: 0.75rem;
+}
+
+.field.is-grouped.is-grouped-multiline:last-child {
+  margin-bottom: -0.75rem;
+}
+
+.field.is-grouped.is-grouped-multiline:not(:last-child) {
+  margin-bottom: 0;
+}
+
+@media screen and (min-width: 769px), print {
+  .field.is-horizontal {
+    display: flex;
+  }
+}
+
+.field-label .label {
+  font-size: inherit;
+}
+
+@media screen and (max-width: 768px) {
+  .field-label {
+    margin-bottom: 0.5rem;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .field-label {
+    flex-basis: 0;
+    flex-grow: 1;
+    flex-shrink: 0;
+    margin-right: 1.5rem;
+    text-align: right;
+  }
+
+  .field-label.is-small {
+    font-size: 0.75rem;
+    padding-top: 0.375em;
+  }
+
+  .field-label.is-normal {
+    padding-top: 0.375em;
+  }
+
+  .field-label.is-medium {
+    font-size: 1.25rem;
+    padding-top: 0.375em;
+  }
+
+  .field-label.is-large {
+    font-size: 1.5rem;
+    padding-top: 0.375em;
+  }
+}
+
+.field-body .field .field {
+  margin-bottom: 0;
+}
+
+@media screen and (min-width: 769px), print {
+  .field-body {
+    display: flex;
+    flex-basis: 0;
+    flex-grow: 5;
+    flex-shrink: 1;
+  }
+
+  .field-body .field {
+    margin-bottom: 0;
+  }
+
+  .field-body > .field {
+    flex-shrink: 1;
+  }
+
+  .field-body > .field:not(.is-narrow) {
+    flex-grow: 1;
+  }
+
+  .field-body > .field:not(:last-child) {
+    margin-right: 0.75rem;
+  }
+}
+
+.control {
+  box-sizing: border-box;
+  clear: both;
+  font-size: 1rem;
+  position: relative;
+  text-align: inherit;
+}
+
+.control.has-icons-left .input:focus ~ .icon,
+.control.has-icons-left .select:focus ~ .icon,
+.control.has-icons-right .input:focus ~ .icon,
+.control.has-icons-right .select:focus ~ .icon {
+  color: #4a4a4a;
+}
+
+.control.has-icons-left .input.is-small ~ .icon,
+.control.has-icons-left .select.is-small ~ .icon,
+.control.has-icons-right .input.is-small ~ .icon,
+.control.has-icons-right .select.is-small ~ .icon {
+  font-size: 0.75rem;
+}
+
+.control.has-icons-left .input.is-medium ~ .icon,
+.control.has-icons-left .select.is-medium ~ .icon,
+.control.has-icons-right .input.is-medium ~ .icon,
+.control.has-icons-right .select.is-medium ~ .icon {
+  font-size: 1.25rem;
+}
+
+.control.has-icons-left .input.is-large ~ .icon,
+.control.has-icons-left .select.is-large ~ .icon,
+.control.has-icons-right .input.is-large ~ .icon,
+.control.has-icons-right .select.is-large ~ .icon {
+  font-size: 1.5rem;
+}
+
+.control.has-icons-left .icon,
+.control.has-icons-right .icon {
+  color: #dbdbdb;
+  height: 2.5em;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  width: 2.5em;
+  z-index: 4;
+}
+
+.control.has-icons-left .input,
+.control.has-icons-left .select select {
+  padding-left: 2.5em;
+}
+
+.control.has-icons-left .icon.is-left {
+  left: 0;
+}
+
+.control.has-icons-right .input,
+.control.has-icons-right .select select {
+  padding-right: 2.5em;
+}
+
+.control.has-icons-right .icon.is-right {
+  right: 0;
+}
+
+.control.is-loading::after {
+  position: absolute !important;
+  right: 0.625em;
+  top: 0.625em;
+  z-index: 4;
+}
+
+.control.is-loading.is-small:after {
+  font-size: 0.75rem;
+}
+
+.control.is-loading.is-medium:after {
+  font-size: 1.25rem;
+}
+
+.control.is-loading.is-large:after {
+  font-size: 1.5rem;
+}
+
+.breadcrumb {
+  font-size: 1rem;
+  white-space: nowrap;
+}
+
+.breadcrumb a {
+  align-items: center;
+  color: #485fc7;
+  display: flex;
+  justify-content: center;
+  padding: 0 0.75em;
+}
+
+.breadcrumb a:hover {
+  color: #363636;
+}
+
+.breadcrumb li {
+  align-items: center;
+  display: flex;
+}
+
+.breadcrumb li:first-child a {
+  padding-left: 0;
+}
+
+.breadcrumb li.is-active a {
+  color: #363636;
+  cursor: default;
+  pointer-events: none;
+}
+
+.breadcrumb li + li::before {
+  color: #b5b5b5;
+  content: "\0002f";
+}
+
+.breadcrumb ol,
+.breadcrumb ul {
+  align-items: flex-start;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+.breadcrumb .icon:first-child {
+  margin-right: 0.5em;
+}
+
+.breadcrumb .icon:last-child {
+  margin-left: 0.5em;
+}
+
+.breadcrumb.is-centered ol,
+.breadcrumb.is-centered ul {
+  justify-content: center;
+}
+
+.breadcrumb.is-right ol,
+.breadcrumb.is-right ul {
+  justify-content: flex-end;
+}
+
+.breadcrumb.is-small {
+  font-size: 0.75rem;
+}
+
+.breadcrumb.is-medium {
+  font-size: 1.25rem;
+}
+
+.breadcrumb.is-large {
+  font-size: 1.5rem;
+}
+
+.breadcrumb.has-arrow-separator li + li::before {
+  content: "\02192";
+}
+
+.breadcrumb.has-bullet-separator li + li::before {
+  content: "\02022";
+}
+
+.breadcrumb.has-dot-separator li + li::before {
+  content: "\000b7";
+}
+
+.breadcrumb.has-succeeds-separator li + li::before {
+  content: "\0227B";
+}
+
+.card {
+  background-color: #fff;
+  border-radius: 0.25rem;
+  box-shadow:
+    0 0.5em 1em -0.125em rgba(10, 10, 10, 0.1),
+    0 0 0 1px rgba(10, 10, 10, 0.02);
+  color: #4a4a4a;
+  max-width: 100%;
+  position: relative;
+}
+
+.card-content:first-child,
+.card-footer:first-child,
+.card-header:first-child {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.card-content:last-child,
+.card-footer:last-child,
+.card-header:last-child {
+  border-bottom-left-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.card-header {
+  background-color: transparent;
+  align-items: stretch;
+  box-shadow: 0 0.125em 0.25em rgba(10, 10, 10, 0.1);
+  display: flex;
+}
+
+.card-header-title {
+  align-items: center;
+  color: #363636;
+  display: flex;
+  flex-grow: 1;
+  font-weight: 700;
+  padding: 0.75rem 1rem;
+}
+
+.card-header-title.is-centered {
+  justify-content: center;
+}
+
+.card-header-icon {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border: none;
+  color: currentColor;
+  font-family: inherit;
+  font-size: 1em;
+  margin: 0;
+  padding: 0;
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  padding: 0.75rem 1rem;
+}
+
+.card-image {
+  display: block;
+  position: relative;
+}
+
+.card-image:first-child img {
+  border-top-left-radius: 0.25rem;
+  border-top-right-radius: 0.25rem;
+}
+
+.card-image:last-child img {
+  border-bottom-left-radius: 0.25rem;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.card-content {
+  background-color: transparent;
+  padding: 1.5rem;
+}
+
+.card-footer {
+  background-color: transparent;
+  border-top: 1px solid #ededed;
+  align-items: stretch;
+  display: flex;
+}
+
+.card-footer-item {
+  align-items: center;
+  display: flex;
+  flex-basis: 0;
+  flex-grow: 1;
+  flex-shrink: 0;
+  justify-content: center;
+  padding: 0.75rem;
+}
+
+.card-footer-item:not(:last-child) {
+  border-right: 1px solid #ededed;
+}
+
+.card .media:not(:last-child) {
+  margin-bottom: 1.5rem;
+}
+
+.dropdown {
+  display: inline-flex;
+  position: relative;
+  vertical-align: top;
+}
+
+.dropdown.is-active .dropdown-menu,
+.dropdown.is-hoverable:hover .dropdown-menu {
+  display: block;
+}
+
+.dropdown.is-right .dropdown-menu {
+  left: auto;
+  right: 0;
+}
+
+.dropdown.is-up .dropdown-menu {
+  bottom: 100%;
+  padding-bottom: 4px;
+  padding-top: initial;
+  top: auto;
+}
+
+.dropdown-menu {
+  display: none;
+  left: 0;
+  min-width: 12rem;
+  padding-top: 4px;
+  position: absolute;
+  top: 100%;
+  z-index: 20;
+}
+
+.dropdown-content {
+  background-color: #fff;
+  border-radius: 4px;
+  box-shadow:
+    0 0.5em 1em -0.125em rgba(10, 10, 10, 0.1),
+    0 0 0 1px rgba(10, 10, 10, 0.02);
+  padding-bottom: 0.5rem;
+  padding-top: 0.5rem;
+}
+
+.dropdown-item {
+  color: #4a4a4a;
+  display: block;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  padding: 0.375rem 1rem;
+  position: relative;
+}
+
+a.dropdown-item,
+button.dropdown-item {
+  padding-right: 3rem;
+  text-align: inherit;
+  white-space: nowrap;
+  width: 100%;
+}
+
+a.dropdown-item:hover,
+button.dropdown-item:hover {
+  background-color: #f5f5f5;
+  color: #0a0a0a;
+}
+
+a.dropdown-item.is-active,
+button.dropdown-item.is-active {
+  background-color: #485fc7;
+  color: #fff;
+}
+
+.dropdown-divider {
+  background-color: #ededed;
+  border: none;
+  display: block;
+  height: 1px;
+  margin: 0.5rem 0;
+}
+
+.level {
+  align-items: center;
+  justify-content: space-between;
+}
+
+.level code {
+  border-radius: 4px;
+}
+
+.level img {
+  display: inline-block;
+  vertical-align: top;
+}
+
+.level.is-mobile {
+  display: flex;
+}
+
+.level.is-mobile .level-left,
+.level.is-mobile .level-right {
+  display: flex;
+}
+
+.level.is-mobile .level-left + .level-right {
+  margin-top: 0;
+}
+
+.level.is-mobile .level-item:not(:last-child) {
+  margin-bottom: 0;
+  margin-right: 0.75rem;
+}
+
+.level.is-mobile .level-item:not(.is-narrow) {
+  flex-grow: 1;
+}
+
+@media screen and (min-width: 769px), print {
+  .level {
+    display: flex;
+  }
+
+  .level > .level-item:not(.is-narrow) {
+    flex-grow: 1;
+  }
+}
+
+.level-item {
+  align-items: center;
+  display: flex;
+  flex-basis: auto;
+  flex-grow: 0;
+  flex-shrink: 0;
+  justify-content: center;
+}
+
+.level-item .subtitle,
+.level-item .title {
+  margin-bottom: 0;
+}
+
+@media screen and (max-width: 768px) {
+  .level-item:not(:last-child) {
+    margin-bottom: 0.75rem;
+  }
+}
+
+.level-left,
+.level-right {
+  flex-basis: auto;
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+
+.level-left .level-item.is-flexible,
+.level-right .level-item.is-flexible {
+  flex-grow: 1;
+}
+
+@media screen and (min-width: 769px), print {
+  .level-left .level-item:not(:last-child),
+  .level-right .level-item:not(:last-child) {
+    margin-right: 0.75rem;
+  }
+}
+
+.level-left {
+  align-items: center;
+  justify-content: flex-start;
+}
+
+@media screen and (max-width: 768px) {
+  .level-left + .level-right {
+    margin-top: 1.5rem;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .level-left {
+    display: flex;
+  }
+}
+
+.level-right {
+  align-items: center;
+  justify-content: flex-end;
+}
+
+@media screen and (min-width: 769px), print {
+  .level-right {
+    display: flex;
+  }
+}
+
+.media {
+  align-items: flex-start;
+  display: flex;
+  text-align: inherit;
+}
+
+.media .content:not(:last-child) {
+  margin-bottom: 0.75rem;
+}
+
+.media .media {
+  border-top: 1px solid rgba(219, 219, 219, 0.5);
+  display: flex;
+  padding-top: 0.75rem;
+}
+
+.media .media .content:not(:last-child),
+.media .media .control:not(:last-child) {
+  margin-bottom: 0.5rem;
+}
+
+.media .media .media {
+  padding-top: 0.5rem;
+}
+
+.media .media .media + .media {
+  margin-top: 0.5rem;
+}
+
+.media + .media {
+  border-top: 1px solid rgba(219, 219, 219, 0.5);
+  margin-top: 1rem;
+  padding-top: 1rem;
+}
+
+.media.is-large + .media {
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+}
+
+.media-left,
+.media-right {
+  flex-basis: auto;
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+
+.media-left {
+  margin-right: 1rem;
+}
+
+.media-right {
+  margin-left: 1rem;
+}
+
+.media-content {
+  flex-basis: auto;
+  flex-grow: 1;
+  flex-shrink: 1;
+  text-align: inherit;
+}
+
+@media screen and (max-width: 768px) {
+  .media-content {
+    overflow-x: auto;
+  }
+}
+
+.menu {
+  font-size: 1rem;
+}
+
+.menu.is-small {
+  font-size: 0.75rem;
+}
+
+.menu.is-medium {
+  font-size: 1.25rem;
+}
+
+.menu.is-large {
+  font-size: 1.5rem;
+}
+
+.menu-list {
+  line-height: 1.25;
+}
+
+.menu-list a {
+  border-radius: 2px;
+  color: #4a4a4a;
+  display: block;
+  padding: 0.5em 0.75em;
+}
+
+.menu-list a:hover {
+  background-color: #f5f5f5;
+  color: #363636;
+}
+
+.menu-list a.is-active {
+  background-color: #485fc7;
+  color: #fff;
+}
+
+.menu-list li ul {
+  border-left: 1px solid #dbdbdb;
+  margin: 0.75em;
+  padding-left: 0.75em;
+}
+
+.menu-label {
+  color: #7a7a7a;
+  font-size: 0.75em;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.menu-label:not(:first-child) {
+  margin-top: 1em;
+}
+
+.menu-label:not(:last-child) {
+  margin-bottom: 1em;
+}
+
+.message {
+  background-color: #f5f5f5;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.message strong {
+  color: currentColor;
+}
+
+.message a:not(.button):not(.tag):not(.dropdown-item) {
+  color: currentColor;
+  text-decoration: underline;
+}
+
+.message.is-small {
+  font-size: 0.75rem;
+}
+
+.message.is-medium {
+  font-size: 1.25rem;
+}
+
+.message.is-large {
+  font-size: 1.5rem;
+}
+
+.message.is-white {
+  background-color: #fff;
+}
+
+.message.is-white .message-header {
+  background-color: #fff;
+  color: #0a0a0a;
+}
+
+.message.is-white .message-body {
+  border-color: #fff;
+}
+
+.message.is-black {
+  background-color: #fafafa;
+}
+
+.message.is-black .message-header {
+  background-color: #0a0a0a;
+  color: #fff;
+}
+
+.message.is-black .message-body {
+  border-color: #0a0a0a;
+}
+
+.message.is-light {
+  background-color: #fafafa;
+}
+
+.message.is-light .message-header {
+  background-color: #f5f5f5;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.message.is-light .message-body {
+  border-color: #f5f5f5;
+}
+
+.message.is-dark {
+  background-color: #fafafa;
+}
+
+.message.is-dark .message-header {
+  background-color: #363636;
+  color: #fff;
+}
+
+.message.is-dark .message-body {
+  border-color: #363636;
+}
+
+.message.is-primary {
+  background-color: #ebfffc;
+}
+
+.message.is-primary .message-header {
+  background-color: #00d1b2;
+  color: #fff;
+}
+
+.message.is-primary .message-body {
+  border-color: #00d1b2;
+  color: #00947e;
+}
+
+.message.is-link {
+  background-color: #eff1fa;
+}
+
+.message.is-link .message-header {
+  background-color: #485fc7;
+  color: #fff;
+}
+
+.message.is-link .message-body {
+  border-color: #485fc7;
+  color: #3850b7;
+}
+
+.message.is-info {
+  background-color: #eff5fb;
+}
+
+.message.is-info .message-header {
+  background-color: #3e8ed0;
+  color: #fff;
+}
+
+.message.is-info .message-body {
+  border-color: #3e8ed0;
+  color: #296fa8;
+}
+
+.message.is-success {
+  background-color: #effaf5;
+}
+
+.message.is-success .message-header {
+  background-color: #48c78e;
+  color: #fff;
+}
+
+.message.is-success .message-body {
+  border-color: #48c78e;
+  color: #257953;
+}
+
+.message.is-warning {
+  background-color: #fffaeb;
+}
+
+.message.is-warning .message-header {
+  background-color: #ffe08a;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.message.is-warning .message-body {
+  border-color: #ffe08a;
+  color: #946c00;
+}
+
+.message.is-danger {
+  background-color: #feecf0;
+}
+
+.message.is-danger .message-header {
+  background-color: #f14668;
+  color: #fff;
+}
+
+.message.is-danger .message-body {
+  border-color: #f14668;
+  color: #cc0f35;
+}
+
+.message-header {
+  align-items: center;
+  background-color: #4a4a4a;
+  border-radius: 4px 4px 0 0;
+  color: #fff;
+  display: flex;
+  font-weight: 700;
+  justify-content: space-between;
+  line-height: 1.25;
+  padding: 0.75em 1em;
+  position: relative;
+}
+
+.message-header .delete {
+  flex-grow: 0;
+  flex-shrink: 0;
+  margin-left: 0.75em;
+}
+
+.message-header + .message-body {
+  border-width: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.message-body {
+  border-color: #dbdbdb;
+  border-radius: 4px;
+  border-style: solid;
+  border-width: 0 0 0 4px;
+  color: #4a4a4a;
+  padding: 1.25em 1.5em;
+}
+
+.message-body code,
+.message-body pre {
+  background-color: #fff;
+}
+
+.message-body pre code {
+  background-color: transparent;
+}
+
+.modal {
+  align-items: center;
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  overflow: hidden;
+  position: fixed;
+  z-index: 40;
+}
+
+.modal.is-active {
+  display: flex;
+}
+
+.modal-background {
+  background-color: rgba(10, 10, 10, 0.86);
+}
+
+.modal-card,
+.modal-content {
+  margin: 0 20px;
+  max-height: calc(100vh - 160px);
+  overflow: auto;
+  position: relative;
+  width: 100%;
+}
+
+@media screen and (min-width: 769px) {
+  .modal-card,
+  .modal-content {
+    margin: 0 auto;
+    max-height: calc(100vh - 40px);
+    width: 640px;
+  }
+}
+
+.modal-close {
+  background: 0 0;
+  height: 40px;
+  position: fixed;
+  right: 20px;
+  top: 20px;
+  width: 40px;
+}
+
+.modal-card {
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 40px);
+  overflow: hidden;
+  -ms-overflow-y: visible;
+}
+
+.modal-card-foot,
+.modal-card-head {
+  align-items: center;
+  background-color: #f5f5f5;
+  display: flex;
+  flex-shrink: 0;
+  justify-content: flex-start;
+  padding: 20px;
+  position: relative;
+}
+
+.modal-card-head {
+  border-bottom: 1px solid #dbdbdb;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+}
+
+.modal-card-title {
+  color: #363636;
+  flex-grow: 1;
+  flex-shrink: 0;
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.modal-card-foot {
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+  border-top: 1px solid #dbdbdb;
+}
+
+.modal-card-foot .button:not(:last-child) {
+  margin-right: 0.5em;
+}
+
+.modal-card-body {
+  -webkit-overflow-scrolling: touch;
+  background-color: #fff;
+  flex-grow: 1;
+  flex-shrink: 1;
+  overflow: auto;
+  padding: 20px;
+}
+
+.navbar {
+  background-color: #fff;
+  min-height: 3.25rem;
+  position: relative;
+  z-index: 30;
+}
+
+.navbar.is-white {
+  background-color: #fff;
+  color: #0a0a0a;
+}
+
+.navbar.is-white .navbar-brand .navbar-link,
+.navbar.is-white .navbar-brand > .navbar-item {
+  color: #0a0a0a;
+}
+
+.navbar.is-white .navbar-brand .navbar-link.is-active,
+.navbar.is-white .navbar-brand .navbar-link:focus,
+.navbar.is-white .navbar-brand .navbar-link:hover,
+.navbar.is-white .navbar-brand > a.navbar-item.is-active,
+.navbar.is-white .navbar-brand > a.navbar-item:focus,
+.navbar.is-white .navbar-brand > a.navbar-item:hover {
+  background-color: #f2f2f2;
+  color: #0a0a0a;
+}
+
+.navbar.is-white .navbar-brand .navbar-link::after {
+  border-color: #0a0a0a;
+}
+
+.navbar.is-white .navbar-burger {
+  color: #0a0a0a;
+}
+
+@media screen and (min-width: 1024px) {
+  .navbar.is-white .navbar-end .navbar-link,
+  .navbar.is-white .navbar-end > .navbar-item,
+  .navbar.is-white .navbar-start .navbar-link,
+  .navbar.is-white .navbar-start > .navbar-item {
+    color: #0a0a0a;
+  }
+
+  .navbar.is-white .navbar-end .navbar-link.is-active,
+  .navbar.is-white .navbar-end .navbar-link:focus,
+  .navbar.is-white .navbar-end .navbar-link:hover,
+  .navbar.is-white .navbar-end > a.navbar-item.is-active,
+  .navbar.is-white .navbar-end > a.navbar-item:focus,
+  .navbar.is-white .navbar-end > a.navbar-item:hover,
+  .navbar.is-white .navbar-start .navbar-link.is-active,
+  .navbar.is-white .navbar-start .navbar-link:focus,
+  .navbar.is-white .navbar-start .navbar-link:hover,
+  .navbar.is-white .navbar-start > a.navbar-item.is-active,
+  .navbar.is-white .navbar-start > a.navbar-item:focus,
+  .navbar.is-white .navbar-start > a.navbar-item:hover {
+    background-color: #f2f2f2;
+    color: #0a0a0a;
+  }
+
+  .navbar.is-white .navbar-end .navbar-link::after,
+  .navbar.is-white .navbar-start .navbar-link::after {
+    border-color: #0a0a0a;
+  }
+
+  .navbar.is-white .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-white .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-white .navbar-item.has-dropdown:hover .navbar-link {
+    background-color: #f2f2f2;
+    color: #0a0a0a;
+  }
+
+  .navbar.is-white .navbar-dropdown a.navbar-item.is-active {
+    background-color: #fff;
+    color: #0a0a0a;
+  }
+}
+
+.navbar.is-black {
+  background-color: #0a0a0a;
+  color: #fff;
+}
+
+.navbar.is-black .navbar-brand .navbar-link,
+.navbar.is-black .navbar-brand > .navbar-item {
+  color: #fff;
+}
+
+.navbar.is-black .navbar-brand .navbar-link.is-active,
+.navbar.is-black .navbar-brand .navbar-link:focus,
+.navbar.is-black .navbar-brand .navbar-link:hover,
+.navbar.is-black .navbar-brand > a.navbar-item.is-active,
+.navbar.is-black .navbar-brand > a.navbar-item:focus,
+.navbar.is-black .navbar-brand > a.navbar-item:hover {
+  background-color: #000;
+  color: #fff;
+}
+
+.navbar.is-black .navbar-brand .navbar-link::after {
+  border-color: #fff;
+}
+
+.navbar.is-black .navbar-burger {
+  color: #fff;
+}
+
+@media screen and (min-width: 1024px) {
+  .navbar.is-black .navbar-end .navbar-link,
+  .navbar.is-black .navbar-end > .navbar-item,
+  .navbar.is-black .navbar-start .navbar-link,
+  .navbar.is-black .navbar-start > .navbar-item {
+    color: #fff;
+  }
+
+  .navbar.is-black .navbar-end .navbar-link.is-active,
+  .navbar.is-black .navbar-end .navbar-link:focus,
+  .navbar.is-black .navbar-end .navbar-link:hover,
+  .navbar.is-black .navbar-end > a.navbar-item.is-active,
+  .navbar.is-black .navbar-end > a.navbar-item:focus,
+  .navbar.is-black .navbar-end > a.navbar-item:hover,
+  .navbar.is-black .navbar-start .navbar-link.is-active,
+  .navbar.is-black .navbar-start .navbar-link:focus,
+  .navbar.is-black .navbar-start .navbar-link:hover,
+  .navbar.is-black .navbar-start > a.navbar-item.is-active,
+  .navbar.is-black .navbar-start > a.navbar-item:focus,
+  .navbar.is-black .navbar-start > a.navbar-item:hover {
+    background-color: #000;
+    color: #fff;
+  }
+
+  .navbar.is-black .navbar-end .navbar-link::after,
+  .navbar.is-black .navbar-start .navbar-link::after {
+    border-color: #fff;
+  }
+
+  .navbar.is-black .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-black .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-black .navbar-item.has-dropdown:hover .navbar-link {
+    background-color: #000;
+    color: #fff;
+  }
+
+  .navbar.is-black .navbar-dropdown a.navbar-item.is-active {
+    background-color: #0a0a0a;
+    color: #fff;
+  }
+}
+
+.navbar.is-light {
+  background-color: #f5f5f5;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.navbar.is-light .navbar-brand .navbar-link,
+.navbar.is-light .navbar-brand > .navbar-item {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.navbar.is-light .navbar-brand .navbar-link.is-active,
+.navbar.is-light .navbar-brand .navbar-link:focus,
+.navbar.is-light .navbar-brand .navbar-link:hover,
+.navbar.is-light .navbar-brand > a.navbar-item.is-active,
+.navbar.is-light .navbar-brand > a.navbar-item:focus,
+.navbar.is-light .navbar-brand > a.navbar-item:hover {
+  background-color: #e8e8e8;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.navbar.is-light .navbar-brand .navbar-link::after {
+  border-color: rgba(0, 0, 0, 0.7);
+}
+
+.navbar.is-light .navbar-burger {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+@media screen and (min-width: 1024px) {
+  .navbar.is-light .navbar-end .navbar-link,
+  .navbar.is-light .navbar-end > .navbar-item,
+  .navbar.is-light .navbar-start .navbar-link,
+  .navbar.is-light .navbar-start > .navbar-item {
+    color: rgba(0, 0, 0, 0.7);
+  }
+
+  .navbar.is-light .navbar-end .navbar-link.is-active,
+  .navbar.is-light .navbar-end .navbar-link:focus,
+  .navbar.is-light .navbar-end .navbar-link:hover,
+  .navbar.is-light .navbar-end > a.navbar-item.is-active,
+  .navbar.is-light .navbar-end > a.navbar-item:focus,
+  .navbar.is-light .navbar-end > a.navbar-item:hover,
+  .navbar.is-light .navbar-start .navbar-link.is-active,
+  .navbar.is-light .navbar-start .navbar-link:focus,
+  .navbar.is-light .navbar-start .navbar-link:hover,
+  .navbar.is-light .navbar-start > a.navbar-item.is-active,
+  .navbar.is-light .navbar-start > a.navbar-item:focus,
+  .navbar.is-light .navbar-start > a.navbar-item:hover {
+    background-color: #e8e8e8;
+    color: rgba(0, 0, 0, 0.7);
+  }
+
+  .navbar.is-light .navbar-end .navbar-link::after,
+  .navbar.is-light .navbar-start .navbar-link::after {
+    border-color: rgba(0, 0, 0, 0.7);
+  }
+
+  .navbar.is-light .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-light .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-light .navbar-item.has-dropdown:hover .navbar-link {
+    background-color: #e8e8e8;
+    color: rgba(0, 0, 0, 0.7);
+  }
+
+  .navbar.is-light .navbar-dropdown a.navbar-item.is-active {
+    background-color: #f5f5f5;
+    color: rgba(0, 0, 0, 0.7);
+  }
+}
+
+.navbar.is-dark {
+  background-color: #363636;
+  color: #fff;
+}
+
+.navbar.is-dark .navbar-brand .navbar-link,
+.navbar.is-dark .navbar-brand > .navbar-item {
+  color: #fff;
+}
+
+.navbar.is-dark .navbar-brand .navbar-link.is-active,
+.navbar.is-dark .navbar-brand .navbar-link:focus,
+.navbar.is-dark .navbar-brand .navbar-link:hover,
+.navbar.is-dark .navbar-brand > a.navbar-item.is-active,
+.navbar.is-dark .navbar-brand > a.navbar-item:focus,
+.navbar.is-dark .navbar-brand > a.navbar-item:hover {
+  background-color: #292929;
+  color: #fff;
+}
+
+.navbar.is-dark .navbar-brand .navbar-link::after {
+  border-color: #fff;
+}
+
+.navbar.is-dark .navbar-burger {
+  color: #fff;
+}
+
+@media screen and (min-width: 1024px) {
+  .navbar.is-dark .navbar-end .navbar-link,
+  .navbar.is-dark .navbar-end > .navbar-item,
+  .navbar.is-dark .navbar-start .navbar-link,
+  .navbar.is-dark .navbar-start > .navbar-item {
+    color: #fff;
+  }
+
+  .navbar.is-dark .navbar-end .navbar-link.is-active,
+  .navbar.is-dark .navbar-end .navbar-link:focus,
+  .navbar.is-dark .navbar-end .navbar-link:hover,
+  .navbar.is-dark .navbar-end > a.navbar-item.is-active,
+  .navbar.is-dark .navbar-end > a.navbar-item:focus,
+  .navbar.is-dark .navbar-end > a.navbar-item:hover,
+  .navbar.is-dark .navbar-start .navbar-link.is-active,
+  .navbar.is-dark .navbar-start .navbar-link:focus,
+  .navbar.is-dark .navbar-start .navbar-link:hover,
+  .navbar.is-dark .navbar-start > a.navbar-item.is-active,
+  .navbar.is-dark .navbar-start > a.navbar-item:focus,
+  .navbar.is-dark .navbar-start > a.navbar-item:hover {
+    background-color: #292929;
+    color: #fff;
+  }
+
+  .navbar.is-dark .navbar-end .navbar-link::after,
+  .navbar.is-dark .navbar-start .navbar-link::after {
+    border-color: #fff;
+  }
+
+  .navbar.is-dark .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-dark .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-dark .navbar-item.has-dropdown:hover .navbar-link {
+    background-color: #292929;
+    color: #fff;
+  }
+
+  .navbar.is-dark .navbar-dropdown a.navbar-item.is-active {
+    background-color: #363636;
+    color: #fff;
+  }
+}
+
+.navbar.is-primary {
+  background-color: #00d1b2;
+  color: #fff;
+}
+
+.navbar.is-primary .navbar-brand .navbar-link,
+.navbar.is-primary .navbar-brand > .navbar-item {
+  color: #fff;
+}
+
+.navbar.is-primary .navbar-brand .navbar-link.is-active,
+.navbar.is-primary .navbar-brand .navbar-link:focus,
+.navbar.is-primary .navbar-brand .navbar-link:hover,
+.navbar.is-primary .navbar-brand > a.navbar-item.is-active,
+.navbar.is-primary .navbar-brand > a.navbar-item:focus,
+.navbar.is-primary .navbar-brand > a.navbar-item:hover {
+  background-color: #00b89c;
+  color: #fff;
+}
+
+.navbar.is-primary .navbar-brand .navbar-link::after {
+  border-color: #fff;
+}
+
+.navbar.is-primary .navbar-burger {
+  color: #fff;
+}
+
+@media screen and (min-width: 1024px) {
+  .navbar.is-primary .navbar-end .navbar-link,
+  .navbar.is-primary .navbar-end > .navbar-item,
+  .navbar.is-primary .navbar-start .navbar-link,
+  .navbar.is-primary .navbar-start > .navbar-item {
+    color: #fff;
+  }
+
+  .navbar.is-primary .navbar-end .navbar-link.is-active,
+  .navbar.is-primary .navbar-end .navbar-link:focus,
+  .navbar.is-primary .navbar-end .navbar-link:hover,
+  .navbar.is-primary .navbar-end > a.navbar-item.is-active,
+  .navbar.is-primary .navbar-end > a.navbar-item:focus,
+  .navbar.is-primary .navbar-end > a.navbar-item:hover,
+  .navbar.is-primary .navbar-start .navbar-link.is-active,
+  .navbar.is-primary .navbar-start .navbar-link:focus,
+  .navbar.is-primary .navbar-start .navbar-link:hover,
+  .navbar.is-primary .navbar-start > a.navbar-item.is-active,
+  .navbar.is-primary .navbar-start > a.navbar-item:focus,
+  .navbar.is-primary .navbar-start > a.navbar-item:hover {
+    background-color: #00b89c;
+    color: #fff;
+  }
+
+  .navbar.is-primary .navbar-end .navbar-link::after,
+  .navbar.is-primary .navbar-start .navbar-link::after {
+    border-color: #fff;
+  }
+
+  .navbar.is-primary .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-primary .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-primary .navbar-item.has-dropdown:hover .navbar-link {
+    background-color: #00b89c;
+    color: #fff;
+  }
+
+  .navbar.is-primary .navbar-dropdown a.navbar-item.is-active {
+    background-color: #00d1b2;
+    color: #fff;
+  }
+}
+
+.navbar.is-link {
+  background-color: #485fc7;
+  color: #fff;
+}
+
+.navbar.is-link .navbar-brand .navbar-link,
+.navbar.is-link .navbar-brand > .navbar-item {
+  color: #fff;
+}
+
+.navbar.is-link .navbar-brand .navbar-link.is-active,
+.navbar.is-link .navbar-brand .navbar-link:focus,
+.navbar.is-link .navbar-brand .navbar-link:hover,
+.navbar.is-link .navbar-brand > a.navbar-item.is-active,
+.navbar.is-link .navbar-brand > a.navbar-item:focus,
+.navbar.is-link .navbar-brand > a.navbar-item:hover {
+  background-color: #3a51bb;
+  color: #fff;
+}
+
+.navbar.is-link .navbar-brand .navbar-link::after {
+  border-color: #fff;
+}
+
+.navbar.is-link .navbar-burger {
+  color: #fff;
+}
+
+@media screen and (min-width: 1024px) {
+  .navbar.is-link .navbar-end .navbar-link,
+  .navbar.is-link .navbar-end > .navbar-item,
+  .navbar.is-link .navbar-start .navbar-link,
+  .navbar.is-link .navbar-start > .navbar-item {
+    color: #fff;
+  }
+
+  .navbar.is-link .navbar-end .navbar-link.is-active,
+  .navbar.is-link .navbar-end .navbar-link:focus,
+  .navbar.is-link .navbar-end .navbar-link:hover,
+  .navbar.is-link .navbar-end > a.navbar-item.is-active,
+  .navbar.is-link .navbar-end > a.navbar-item:focus,
+  .navbar.is-link .navbar-end > a.navbar-item:hover,
+  .navbar.is-link .navbar-start .navbar-link.is-active,
+  .navbar.is-link .navbar-start .navbar-link:focus,
+  .navbar.is-link .navbar-start .navbar-link:hover,
+  .navbar.is-link .navbar-start > a.navbar-item.is-active,
+  .navbar.is-link .navbar-start > a.navbar-item:focus,
+  .navbar.is-link .navbar-start > a.navbar-item:hover {
+    background-color: #3a51bb;
+    color: #fff;
+  }
+
+  .navbar.is-link .navbar-end .navbar-link::after,
+  .navbar.is-link .navbar-start .navbar-link::after {
+    border-color: #fff;
+  }
+
+  .navbar.is-link .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-link .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-link .navbar-item.has-dropdown:hover .navbar-link {
+    background-color: #3a51bb;
+    color: #fff;
+  }
+
+  .navbar.is-link .navbar-dropdown a.navbar-item.is-active {
+    background-color: #485fc7;
+    color: #fff;
+  }
+}
+
+.navbar.is-info {
+  background-color: #3e8ed0;
+  color: #fff;
+}
+
+.navbar.is-info .navbar-brand .navbar-link,
+.navbar.is-info .navbar-brand > .navbar-item {
+  color: #fff;
+}
+
+.navbar.is-info .navbar-brand .navbar-link.is-active,
+.navbar.is-info .navbar-brand .navbar-link:focus,
+.navbar.is-info .navbar-brand .navbar-link:hover,
+.navbar.is-info .navbar-brand > a.navbar-item.is-active,
+.navbar.is-info .navbar-brand > a.navbar-item:focus,
+.navbar.is-info .navbar-brand > a.navbar-item:hover {
+  background-color: #3082c5;
+  color: #fff;
+}
+
+.navbar.is-info .navbar-brand .navbar-link::after {
+  border-color: #fff;
+}
+
+.navbar.is-info .navbar-burger {
+  color: #fff;
+}
+
+@media screen and (min-width: 1024px) {
+  .navbar.is-info .navbar-end .navbar-link,
+  .navbar.is-info .navbar-end > .navbar-item,
+  .navbar.is-info .navbar-start .navbar-link,
+  .navbar.is-info .navbar-start > .navbar-item {
+    color: #fff;
+  }
+
+  .navbar.is-info .navbar-end .navbar-link.is-active,
+  .navbar.is-info .navbar-end .navbar-link:focus,
+  .navbar.is-info .navbar-end .navbar-link:hover,
+  .navbar.is-info .navbar-end > a.navbar-item.is-active,
+  .navbar.is-info .navbar-end > a.navbar-item:focus,
+  .navbar.is-info .navbar-end > a.navbar-item:hover,
+  .navbar.is-info .navbar-start .navbar-link.is-active,
+  .navbar.is-info .navbar-start .navbar-link:focus,
+  .navbar.is-info .navbar-start .navbar-link:hover,
+  .navbar.is-info .navbar-start > a.navbar-item.is-active,
+  .navbar.is-info .navbar-start > a.navbar-item:focus,
+  .navbar.is-info .navbar-start > a.navbar-item:hover {
+    background-color: #3082c5;
+    color: #fff;
+  }
+
+  .navbar.is-info .navbar-end .navbar-link::after,
+  .navbar.is-info .navbar-start .navbar-link::after {
+    border-color: #fff;
+  }
+
+  .navbar.is-info .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-info .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-info .navbar-item.has-dropdown:hover .navbar-link {
+    background-color: #3082c5;
+    color: #fff;
+  }
+
+  .navbar.is-info .navbar-dropdown a.navbar-item.is-active {
+    background-color: #3e8ed0;
+    color: #fff;
+  }
+}
+
+.navbar.is-success {
+  background-color: #48c78e;
+  color: #fff;
+}
+
+.navbar.is-success .navbar-brand .navbar-link,
+.navbar.is-success .navbar-brand > .navbar-item {
+  color: #fff;
+}
+
+.navbar.is-success .navbar-brand .navbar-link.is-active,
+.navbar.is-success .navbar-brand .navbar-link:focus,
+.navbar.is-success .navbar-brand .navbar-link:hover,
+.navbar.is-success .navbar-brand > a.navbar-item.is-active,
+.navbar.is-success .navbar-brand > a.navbar-item:focus,
+.navbar.is-success .navbar-brand > a.navbar-item:hover {
+  background-color: #3abb81;
+  color: #fff;
+}
+
+.navbar.is-success .navbar-brand .navbar-link::after {
+  border-color: #fff;
+}
+
+.navbar.is-success .navbar-burger {
+  color: #fff;
+}
+
+@media screen and (min-width: 1024px) {
+  .navbar.is-success .navbar-end .navbar-link,
+  .navbar.is-success .navbar-end > .navbar-item,
+  .navbar.is-success .navbar-start .navbar-link,
+  .navbar.is-success .navbar-start > .navbar-item {
+    color: #fff;
+  }
+
+  .navbar.is-success .navbar-end .navbar-link.is-active,
+  .navbar.is-success .navbar-end .navbar-link:focus,
+  .navbar.is-success .navbar-end .navbar-link:hover,
+  .navbar.is-success .navbar-end > a.navbar-item.is-active,
+  .navbar.is-success .navbar-end > a.navbar-item:focus,
+  .navbar.is-success .navbar-end > a.navbar-item:hover,
+  .navbar.is-success .navbar-start .navbar-link.is-active,
+  .navbar.is-success .navbar-start .navbar-link:focus,
+  .navbar.is-success .navbar-start .navbar-link:hover,
+  .navbar.is-success .navbar-start > a.navbar-item.is-active,
+  .navbar.is-success .navbar-start > a.navbar-item:focus,
+  .navbar.is-success .navbar-start > a.navbar-item:hover {
+    background-color: #3abb81;
+    color: #fff;
+  }
+
+  .navbar.is-success .navbar-end .navbar-link::after,
+  .navbar.is-success .navbar-start .navbar-link::after {
+    border-color: #fff;
+  }
+
+  .navbar.is-success .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-success .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-success .navbar-item.has-dropdown:hover .navbar-link {
+    background-color: #3abb81;
+    color: #fff;
+  }
+
+  .navbar.is-success .navbar-dropdown a.navbar-item.is-active {
+    background-color: #48c78e;
+    color: #fff;
+  }
+}
+
+.navbar.is-warning {
+  background-color: #ffe08a;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.navbar.is-warning .navbar-brand .navbar-link,
+.navbar.is-warning .navbar-brand > .navbar-item {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.navbar.is-warning .navbar-brand .navbar-link.is-active,
+.navbar.is-warning .navbar-brand .navbar-link:focus,
+.navbar.is-warning .navbar-brand .navbar-link:hover,
+.navbar.is-warning .navbar-brand > a.navbar-item.is-active,
+.navbar.is-warning .navbar-brand > a.navbar-item:focus,
+.navbar.is-warning .navbar-brand > a.navbar-item:hover {
+  background-color: #ffd970;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.navbar.is-warning .navbar-brand .navbar-link::after {
+  border-color: rgba(0, 0, 0, 0.7);
+}
+
+.navbar.is-warning .navbar-burger {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+@media screen and (min-width: 1024px) {
+  .navbar.is-warning .navbar-end .navbar-link,
+  .navbar.is-warning .navbar-end > .navbar-item,
+  .navbar.is-warning .navbar-start .navbar-link,
+  .navbar.is-warning .navbar-start > .navbar-item {
+    color: rgba(0, 0, 0, 0.7);
+  }
+
+  .navbar.is-warning .navbar-end .navbar-link.is-active,
+  .navbar.is-warning .navbar-end .navbar-link:focus,
+  .navbar.is-warning .navbar-end .navbar-link:hover,
+  .navbar.is-warning .navbar-end > a.navbar-item.is-active,
+  .navbar.is-warning .navbar-end > a.navbar-item:focus,
+  .navbar.is-warning .navbar-end > a.navbar-item:hover,
+  .navbar.is-warning .navbar-start .navbar-link.is-active,
+  .navbar.is-warning .navbar-start .navbar-link:focus,
+  .navbar.is-warning .navbar-start .navbar-link:hover,
+  .navbar.is-warning .navbar-start > a.navbar-item.is-active,
+  .navbar.is-warning .navbar-start > a.navbar-item:focus,
+  .navbar.is-warning .navbar-start > a.navbar-item:hover {
+    background-color: #ffd970;
+    color: rgba(0, 0, 0, 0.7);
+  }
+
+  .navbar.is-warning .navbar-end .navbar-link::after,
+  .navbar.is-warning .navbar-start .navbar-link::after {
+    border-color: rgba(0, 0, 0, 0.7);
+  }
+
+  .navbar.is-warning .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-warning .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-warning .navbar-item.has-dropdown:hover .navbar-link {
+    background-color: #ffd970;
+    color: rgba(0, 0, 0, 0.7);
+  }
+
+  .navbar.is-warning .navbar-dropdown a.navbar-item.is-active {
+    background-color: #ffe08a;
+    color: rgba(0, 0, 0, 0.7);
+  }
+}
+
+.navbar.is-danger {
+  background-color: #f14668;
+  color: #fff;
+}
+
+.navbar.is-danger .navbar-brand .navbar-link,
+.navbar.is-danger .navbar-brand > .navbar-item {
+  color: #fff;
+}
+
+.navbar.is-danger .navbar-brand .navbar-link.is-active,
+.navbar.is-danger .navbar-brand .navbar-link:focus,
+.navbar.is-danger .navbar-brand .navbar-link:hover,
+.navbar.is-danger .navbar-brand > a.navbar-item.is-active,
+.navbar.is-danger .navbar-brand > a.navbar-item:focus,
+.navbar.is-danger .navbar-brand > a.navbar-item:hover {
+  background-color: #ef2e55;
+  color: #fff;
+}
+
+.navbar.is-danger .navbar-brand .navbar-link::after {
+  border-color: #fff;
+}
+
+.navbar.is-danger .navbar-burger {
+  color: #fff;
+}
+
+@media screen and (min-width: 1024px) {
+  .navbar.is-danger .navbar-end .navbar-link,
+  .navbar.is-danger .navbar-end > .navbar-item,
+  .navbar.is-danger .navbar-start .navbar-link,
+  .navbar.is-danger .navbar-start > .navbar-item {
+    color: #fff;
+  }
+
+  .navbar.is-danger .navbar-end .navbar-link.is-active,
+  .navbar.is-danger .navbar-end .navbar-link:focus,
+  .navbar.is-danger .navbar-end .navbar-link:hover,
+  .navbar.is-danger .navbar-end > a.navbar-item.is-active,
+  .navbar.is-danger .navbar-end > a.navbar-item:focus,
+  .navbar.is-danger .navbar-end > a.navbar-item:hover,
+  .navbar.is-danger .navbar-start .navbar-link.is-active,
+  .navbar.is-danger .navbar-start .navbar-link:focus,
+  .navbar.is-danger .navbar-start .navbar-link:hover,
+  .navbar.is-danger .navbar-start > a.navbar-item.is-active,
+  .navbar.is-danger .navbar-start > a.navbar-item:focus,
+  .navbar.is-danger .navbar-start > a.navbar-item:hover {
+    background-color: #ef2e55;
+    color: #fff;
+  }
+
+  .navbar.is-danger .navbar-end .navbar-link::after,
+  .navbar.is-danger .navbar-start .navbar-link::after {
+    border-color: #fff;
+  }
+
+  .navbar.is-danger .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-danger .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar.is-danger .navbar-item.has-dropdown:hover .navbar-link {
+    background-color: #ef2e55;
+    color: #fff;
+  }
+
+  .navbar.is-danger .navbar-dropdown a.navbar-item.is-active {
+    background-color: #f14668;
+    color: #fff;
+  }
+}
+
+.navbar > .container {
+  align-items: stretch;
+  display: flex;
+  min-height: 3.25rem;
+  width: 100%;
+}
+
+.navbar.has-shadow {
+  box-shadow: 0 2px 0 0 #f5f5f5;
+}
+
+.navbar.is-fixed-bottom,
+.navbar.is-fixed-top {
+  left: 0;
+  position: fixed;
+  right: 0;
+  z-index: 30;
+}
+
+.navbar.is-fixed-bottom {
+  bottom: 0;
+}
+
+.navbar.is-fixed-bottom.has-shadow {
+  box-shadow: 0 -2px 0 0 #f5f5f5;
+}
+
+.navbar.is-fixed-top {
+  top: 0;
+}
+
+body.has-navbar-fixed-top,
+html.has-navbar-fixed-top {
+  padding-top: 3.25rem;
+}
+
+body.has-navbar-fixed-bottom,
+html.has-navbar-fixed-bottom {
+  padding-bottom: 3.25rem;
+}
+
+.navbar-brand,
+.navbar-tabs {
+  align-items: stretch;
+  display: flex;
+  flex-shrink: 0;
+  min-height: 3.25rem;
+}
+
+.navbar-brand a.navbar-item:focus,
+.navbar-brand a.navbar-item:hover {
+  background-color: transparent;
+}
+
+.navbar-tabs {
+  -webkit-overflow-scrolling: touch;
+  max-width: 100vw;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.navbar-burger {
+  color: #4a4a4a;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+  background: 0 0;
+  border: none;
+  cursor: pointer;
+  display: block;
+  height: 3.25rem;
+  position: relative;
+  width: 3.25rem;
+  margin-left: auto;
+}
+
+.navbar-burger span {
+  background-color: currentColor;
+  display: block;
+  height: 1px;
+  left: calc(50% - 8px);
+  position: absolute;
+  transform-origin: center;
+  transition-duration: 86ms;
+  transition-property: background-color, opacity, transform;
+  transition-timing-function: ease-out;
+  width: 16px;
+}
+
+.navbar-burger span:first-child {
+  top: calc(50% - 6px);
+}
+
+.navbar-burger span:nth-child(2) {
+  top: calc(50% - 1px);
+}
+
+.navbar-burger span:nth-child(3) {
+  top: calc(50% + 4px);
+}
+
+.navbar-burger:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.navbar-burger.is-active span:first-child {
+  transform: translateY(5px) rotate(45deg);
+}
+
+.navbar-burger.is-active span:nth-child(2) {
+  opacity: 0;
+}
+
+.navbar-burger.is-active span:nth-child(3) {
+  transform: translateY(-5px) rotate(-45deg);
+}
+
+.navbar-menu {
+  display: none;
+}
+
+.navbar-item,
+.navbar-link {
+  color: #4a4a4a;
+  display: block;
+  line-height: 1.5;
+  padding: 0.5rem 0.75rem;
+  position: relative;
+}
+
+.navbar-item .icon:only-child,
+.navbar-link .icon:only-child {
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+}
+
+.navbar-link,
+a.navbar-item {
+  cursor: pointer;
+}
+
+.navbar-link.is-active,
+.navbar-link:focus,
+.navbar-link:focus-within,
+.navbar-link:hover,
+a.navbar-item.is-active,
+a.navbar-item:focus,
+a.navbar-item:focus-within,
+a.navbar-item:hover {
+  background-color: #fafafa;
+  color: #485fc7;
+}
+
+.navbar-item {
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+
+.navbar-item img {
+  max-height: 1.75rem;
+}
+
+.navbar-item.has-dropdown {
+  padding: 0;
+}
+
+.navbar-item.is-expanded {
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+.navbar-item.is-tab {
+  border-bottom: 1px solid transparent;
+  min-height: 3.25rem;
+  padding-bottom: calc(0.5rem - 1px);
+}
+
+.navbar-item.is-tab:focus,
+.navbar-item.is-tab:hover {
+  background-color: transparent;
+  border-bottom-color: #485fc7;
+}
+
+.navbar-item.is-tab.is-active {
+  background-color: transparent;
+  border-bottom-color: #485fc7;
+  border-bottom-style: solid;
+  border-bottom-width: 3px;
+  color: #485fc7;
+  padding-bottom: calc(0.5rem - 3px);
+}
+
+.navbar-content {
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+.navbar-link:not(.is-arrowless) {
+  padding-right: 2.5em;
+}
+
+.navbar-link:not(.is-arrowless)::after {
+  border-color: #485fc7;
+  margin-top: -0.375em;
+  right: 1.125em;
+}
+
+.navbar-dropdown {
+  font-size: 0.875rem;
+  padding-bottom: 0.5rem;
+  padding-top: 0.5rem;
+}
+
+.navbar-dropdown .navbar-item {
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
+.navbar-divider {
+  background-color: #f5f5f5;
+  border: none;
+  display: none;
+  height: 2px;
+  margin: 0.5rem 0;
+}
+
+@media screen and (max-width: 1023px) {
+  .navbar > .container {
+    display: block;
+  }
+
+  .navbar-brand .navbar-item,
+  .navbar-tabs .navbar-item {
+    align-items: center;
+    display: flex;
+  }
+
+  .navbar-link::after {
+    display: none;
+  }
+
+  .navbar-menu {
+    background-color: #fff;
+    box-shadow: 0 8px 16px rgba(10, 10, 10, 0.1);
+    padding: 0.5rem 0;
+  }
+
+  .navbar-menu.is-active {
+    display: block;
+  }
+
+  .navbar.is-fixed-bottom-touch,
+  .navbar.is-fixed-top-touch {
+    left: 0;
+    position: fixed;
+    right: 0;
+    z-index: 30;
+  }
+
+  .navbar.is-fixed-bottom-touch {
+    bottom: 0;
+  }
+
+  .navbar.is-fixed-bottom-touch.has-shadow {
+    box-shadow: 0 -2px 3px rgba(10, 10, 10, 0.1);
+  }
+
+  .navbar.is-fixed-top-touch {
+    top: 0;
+  }
+
+  .navbar.is-fixed-top .navbar-menu,
+  .navbar.is-fixed-top-touch .navbar-menu {
+    -webkit-overflow-scrolling: touch;
+    max-height: calc(100vh - 3.25rem);
+    overflow: auto;
+  }
+
+  body.has-navbar-fixed-top-touch,
+  html.has-navbar-fixed-top-touch {
+    padding-top: 3.25rem;
+  }
+
+  body.has-navbar-fixed-bottom-touch,
+  html.has-navbar-fixed-bottom-touch {
+    padding-bottom: 3.25rem;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .navbar,
+  .navbar-end,
+  .navbar-menu,
+  .navbar-start {
+    align-items: stretch;
+    display: flex;
+  }
+
+  .navbar {
+    min-height: 3.25rem;
+  }
+
+  .navbar.is-spaced {
+    padding: 1rem 2rem;
+  }
+
+  .navbar.is-spaced .navbar-end,
+  .navbar.is-spaced .navbar-start {
+    align-items: center;
+  }
+
+  .navbar.is-spaced .navbar-link,
+  .navbar.is-spaced a.navbar-item {
+    border-radius: 4px;
+  }
+
+  .navbar.is-transparent .navbar-link.is-active,
+  .navbar.is-transparent .navbar-link:focus,
+  .navbar.is-transparent .navbar-link:hover,
+  .navbar.is-transparent a.navbar-item.is-active,
+  .navbar.is-transparent a.navbar-item:focus,
+  .navbar.is-transparent a.navbar-item:hover {
+    background-color: transparent !important;
+  }
+
+  .navbar.is-transparent .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar.is-transparent
+    .navbar-item.has-dropdown.is-hoverable:focus
+    .navbar-link,
+  .navbar.is-transparent
+    .navbar-item.has-dropdown.is-hoverable:focus-within
+    .navbar-link,
+  .navbar.is-transparent
+    .navbar-item.has-dropdown.is-hoverable:hover
+    .navbar-link {
+    background-color: transparent !important;
+  }
+
+  .navbar.is-transparent .navbar-dropdown a.navbar-item:focus,
+  .navbar.is-transparent .navbar-dropdown a.navbar-item:hover {
+    background-color: #f5f5f5;
+    color: #0a0a0a;
+  }
+
+  .navbar.is-transparent .navbar-dropdown a.navbar-item.is-active {
+    background-color: #f5f5f5;
+    color: #485fc7;
+  }
+
+  .navbar-burger {
+    display: none;
+  }
+
+  .navbar-item,
+  .navbar-link {
+    align-items: center;
+    display: flex;
+  }
+
+  .navbar-item.has-dropdown {
+    align-items: stretch;
+  }
+
+  .navbar-item.has-dropdown-up .navbar-link::after {
+    transform: rotate(135deg) translate(0.25em, -0.25em);
+  }
+
+  .navbar-item.has-dropdown-up .navbar-dropdown {
+    border-bottom: 2px solid #dbdbdb;
+    border-radius: 6px 6px 0 0;
+    border-top: none;
+    bottom: 100%;
+    box-shadow: 0 -8px 8px rgba(10, 10, 10, 0.1);
+    top: auto;
+  }
+
+  .navbar-item.is-active .navbar-dropdown,
+  .navbar-item.is-hoverable:focus .navbar-dropdown,
+  .navbar-item.is-hoverable:focus-within .navbar-dropdown,
+  .navbar-item.is-hoverable:hover .navbar-dropdown {
+    display: block;
+  }
+
+  .navbar-item.is-active .navbar-dropdown.is-boxed,
+  .navbar-item.is-hoverable:focus .navbar-dropdown.is-boxed,
+  .navbar-item.is-hoverable:focus-within .navbar-dropdown.is-boxed,
+  .navbar-item.is-hoverable:hover .navbar-dropdown.is-boxed,
+  .navbar.is-spaced .navbar-item.is-active .navbar-dropdown,
+  .navbar.is-spaced .navbar-item.is-hoverable:focus .navbar-dropdown,
+  .navbar.is-spaced .navbar-item.is-hoverable:focus-within .navbar-dropdown,
+  .navbar.is-spaced .navbar-item.is-hoverable:hover .navbar-dropdown {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .navbar-menu {
+    flex-grow: 1;
+    flex-shrink: 0;
+  }
+
+  .navbar-start {
+    justify-content: flex-start;
+    margin-right: auto;
+  }
+
+  .navbar-end {
+    justify-content: flex-end;
+    margin-left: auto;
+  }
+
+  .navbar-dropdown {
+    background-color: #fff;
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius: 6px;
+    border-top: 2px solid #dbdbdb;
+    box-shadow: 0 8px 8px rgba(10, 10, 10, 0.1);
+    display: none;
+    font-size: 0.875rem;
+    left: 0;
+    min-width: 100%;
+    position: absolute;
+    top: 100%;
+    z-index: 20;
+  }
+
+  .navbar-dropdown .navbar-item {
+    padding: 0.375rem 1rem;
+    white-space: nowrap;
+  }
+
+  .navbar-dropdown a.navbar-item {
+    padding-right: 3rem;
+  }
+
+  .navbar-dropdown a.navbar-item:focus,
+  .navbar-dropdown a.navbar-item:hover {
+    background-color: #f5f5f5;
+    color: #0a0a0a;
+  }
+
+  .navbar-dropdown a.navbar-item.is-active {
+    background-color: #f5f5f5;
+    color: #485fc7;
+  }
+
+  .navbar-dropdown.is-boxed,
+  .navbar.is-spaced .navbar-dropdown {
+    border-radius: 6px;
+    border-top: none;
+    box-shadow:
+      0 8px 8px rgba(10, 10, 10, 0.1),
+      0 0 0 1px rgba(10, 10, 10, 0.1);
+    display: block;
+    opacity: 0;
+    pointer-events: none;
+    top: calc(100% + (-4px));
+    transform: translateY(-5px);
+    transition-duration: 86ms;
+    transition-property: opacity, transform;
+  }
+
+  .navbar-dropdown.is-right {
+    left: auto;
+    right: 0;
+  }
+
+  .navbar-divider {
+    display: block;
+  }
+
+  .container > .navbar .navbar-brand,
+  .navbar > .container .navbar-brand {
+    margin-left: -0.75rem;
+  }
+
+  .container > .navbar .navbar-menu,
+  .navbar > .container .navbar-menu {
+    margin-right: -0.75rem;
+  }
+
+  .navbar.is-fixed-bottom-desktop,
+  .navbar.is-fixed-top-desktop {
+    left: 0;
+    position: fixed;
+    right: 0;
+    z-index: 30;
+  }
+
+  .navbar.is-fixed-bottom-desktop {
+    bottom: 0;
+  }
+
+  .navbar.is-fixed-bottom-desktop.has-shadow {
+    box-shadow: 0 -2px 3px rgba(10, 10, 10, 0.1);
+  }
+
+  .navbar.is-fixed-top-desktop {
+    top: 0;
+  }
+
+  body.has-navbar-fixed-top-desktop,
+  html.has-navbar-fixed-top-desktop {
+    padding-top: 3.25rem;
+  }
+
+  body.has-navbar-fixed-bottom-desktop,
+  html.has-navbar-fixed-bottom-desktop {
+    padding-bottom: 3.25rem;
+  }
+
+  body.has-spaced-navbar-fixed-top,
+  html.has-spaced-navbar-fixed-top {
+    padding-top: 5.25rem;
+  }
+
+  body.has-spaced-navbar-fixed-bottom,
+  html.has-spaced-navbar-fixed-bottom {
+    padding-bottom: 5.25rem;
+  }
+
+  .navbar-link.is-active,
+  a.navbar-item.is-active {
+    color: #0a0a0a;
+  }
+
+  .navbar-link.is-active:not(:focus):not(:hover),
+  a.navbar-item.is-active:not(:focus):not(:hover) {
+    background-color: transparent;
+  }
+
+  .navbar-item.has-dropdown.is-active .navbar-link,
+  .navbar-item.has-dropdown:focus .navbar-link,
+  .navbar-item.has-dropdown:hover .navbar-link {
+    background-color: #fafafa;
+  }
+}
+
+.hero.is-fullheight-with-navbar {
+  min-height: calc(100vh - 3.25rem);
+}
+
+.pagination {
+  font-size: 1rem;
+  margin: -0.25rem;
+}
+
+.pagination.is-small {
+  font-size: 0.75rem;
+}
+
+.pagination.is-medium {
+  font-size: 1.25rem;
+}
+
+.pagination.is-large {
+  font-size: 1.5rem;
+}
+
+.pagination.is-rounded .pagination-next,
+.pagination.is-rounded .pagination-previous {
+  padding-left: 1em;
+  padding-right: 1em;
+  border-radius: 9999px;
+}
+
+.pagination.is-rounded .pagination-link {
+  border-radius: 9999px;
+}
+
+.pagination,
+.pagination-list {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  text-align: center;
+}
+
+.pagination-ellipsis,
+.pagination-link,
+.pagination-next,
+.pagination-previous {
+  font-size: 1em;
+  justify-content: center;
+  margin: 0.25rem;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+  text-align: center;
+}
+
+.pagination-link,
+.pagination-next,
+.pagination-previous {
+  border-color: #dbdbdb;
+  color: #363636;
+  min-width: 2.5em;
+}
+
+.pagination-link:hover,
+.pagination-next:hover,
+.pagination-previous:hover {
+  border-color: #b5b5b5;
+  color: #363636;
+}
+
+.pagination-link:focus,
+.pagination-next:focus,
+.pagination-previous:focus {
+  border-color: #485fc7;
+}
+
+.pagination-link:active,
+.pagination-next:active,
+.pagination-previous:active {
+  box-shadow: inset 0 1px 2px rgba(10, 10, 10, 0.2);
+}
+
+.pagination-link.is-disabled,
+.pagination-link[disabled],
+.pagination-next.is-disabled,
+.pagination-next[disabled],
+.pagination-previous.is-disabled,
+.pagination-previous[disabled] {
+  background-color: #dbdbdb;
+  border-color: #dbdbdb;
+  box-shadow: none;
+  color: #7a7a7a;
+  opacity: 0.5;
+}
+
+.pagination-next,
+.pagination-previous {
+  padding-left: 0.75em;
+  padding-right: 0.75em;
+  white-space: nowrap;
+}
+
+.pagination-link.is-current {
+  background-color: #485fc7;
+  border-color: #485fc7;
+  color: #fff;
+}
+
+.pagination-ellipsis {
+  color: #b5b5b5;
+  pointer-events: none;
+}
+
+.pagination-list {
+  flex-wrap: wrap;
+}
+
+.pagination-list li {
+  list-style: none;
+}
+
+@media screen and (max-width: 768px) {
+  .pagination {
+    flex-wrap: wrap;
+  }
+
+  .pagination-next,
+  .pagination-previous {
+    flex-grow: 1;
+    flex-shrink: 1;
+  }
+
+  .pagination-list li {
+    flex-grow: 1;
+    flex-shrink: 1;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .pagination-list {
+    flex-grow: 1;
+    flex-shrink: 1;
+    justify-content: flex-start;
+    order: 1;
+  }
+
+  .pagination-ellipsis,
+  .pagination-link,
+  .pagination-next,
+  .pagination-previous {
+    margin-bottom: 0;
+    margin-top: 0;
+  }
+
+  .pagination-previous {
+    order: 2;
+  }
+
+  .pagination-next {
+    order: 3;
+  }
+
+  .pagination {
+    justify-content: space-between;
+    margin-bottom: 0;
+    margin-top: 0;
+  }
+
+  .pagination.is-centered .pagination-previous {
+    order: 1;
+  }
+
+  .pagination.is-centered .pagination-list {
+    justify-content: center;
+    order: 2;
+  }
+
+  .pagination.is-centered .pagination-next {
+    order: 3;
+  }
+
+  .pagination.is-right .pagination-previous {
+    order: 1;
+  }
+
+  .pagination.is-right .pagination-next {
+    order: 2;
+  }
+
+  .pagination.is-right .pagination-list {
+    justify-content: flex-end;
+    order: 3;
+  }
+}
+
+.panel {
+  border-radius: 6px;
+  box-shadow:
+    0 0.5em 1em -0.125em rgba(10, 10, 10, 0.1),
+    0 0 0 1px rgba(10, 10, 10, 0.02);
+  font-size: 1rem;
+}
+
+.panel:not(:last-child) {
+  margin-bottom: 1.5rem;
+}
+
+.panel.is-white .panel-heading {
+  background-color: #fff;
+  color: #0a0a0a;
+}
+
+.panel.is-white .panel-tabs a.is-active {
+  border-bottom-color: #fff;
+}
+
+.panel.is-white .panel-block.is-active .panel-icon {
+  color: #fff;
+}
+
+.panel.is-black .panel-heading {
+  background-color: #0a0a0a;
+  color: #fff;
+}
+
+.panel.is-black .panel-tabs a.is-active {
+  border-bottom-color: #0a0a0a;
+}
+
+.panel.is-black .panel-block.is-active .panel-icon {
+  color: #0a0a0a;
+}
+
+.panel.is-light .panel-heading {
+  background-color: #f5f5f5;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.panel.is-light .panel-tabs a.is-active {
+  border-bottom-color: #f5f5f5;
+}
+
+.panel.is-light .panel-block.is-active .panel-icon {
+  color: #f5f5f5;
+}
+
+.panel.is-dark .panel-heading {
+  background-color: #363636;
+  color: #fff;
+}
+
+.panel.is-dark .panel-tabs a.is-active {
+  border-bottom-color: #363636;
+}
+
+.panel.is-dark .panel-block.is-active .panel-icon {
+  color: #363636;
+}
+
+.panel.is-primary .panel-heading {
+  background-color: #00d1b2;
+  color: #fff;
+}
+
+.panel.is-primary .panel-tabs a.is-active {
+  border-bottom-color: #00d1b2;
+}
+
+.panel.is-primary .panel-block.is-active .panel-icon {
+  color: #00d1b2;
+}
+
+.panel.is-link .panel-heading {
+  background-color: #485fc7;
+  color: #fff;
+}
+
+.panel.is-link .panel-tabs a.is-active {
+  border-bottom-color: #485fc7;
+}
+
+.panel.is-link .panel-block.is-active .panel-icon {
+  color: #485fc7;
+}
+
+.panel.is-info .panel-heading {
+  background-color: #3e8ed0;
+  color: #fff;
+}
+
+.panel.is-info .panel-tabs a.is-active {
+  border-bottom-color: #3e8ed0;
+}
+
+.panel.is-info .panel-block.is-active .panel-icon {
+  color: #3e8ed0;
+}
+
+.panel.is-success .panel-heading {
+  background-color: #48c78e;
+  color: #fff;
+}
+
+.panel.is-success .panel-tabs a.is-active {
+  border-bottom-color: #48c78e;
+}
+
+.panel.is-success .panel-block.is-active .panel-icon {
+  color: #48c78e;
+}
+
+.panel.is-warning .panel-heading {
+  background-color: #ffe08a;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.panel.is-warning .panel-tabs a.is-active {
+  border-bottom-color: #ffe08a;
+}
+
+.panel.is-warning .panel-block.is-active .panel-icon {
+  color: #ffe08a;
+}
+
+.panel.is-danger .panel-heading {
+  background-color: #f14668;
+  color: #fff;
+}
+
+.panel.is-danger .panel-tabs a.is-active {
+  border-bottom-color: #f14668;
+}
+
+.panel.is-danger .panel-block.is-active .panel-icon {
+  color: #f14668;
+}
+
+.panel-block:not(:last-child),
+.panel-tabs:not(:last-child) {
+  border-bottom: 1px solid #ededed;
+}
+
+.panel-heading {
+  background-color: #ededed;
+  border-radius: 6px 6px 0 0;
+  color: #363636;
+  font-size: 1.25em;
+  font-weight: 700;
+  line-height: 1.25;
+  padding: 0.75em 1em;
+}
+
+.panel-tabs {
+  align-items: flex-end;
+  display: flex;
+  font-size: 0.875em;
+  justify-content: center;
+}
+
+.panel-tabs a {
+  border-bottom: 1px solid #dbdbdb;
+  margin-bottom: -1px;
+  padding: 0.5em;
+}
+
+.panel-tabs a.is-active {
+  border-bottom-color: #4a4a4a;
+  color: #363636;
+}
+
+.panel-list a {
+  color: #4a4a4a;
+}
+
+.panel-list a:hover {
+  color: #485fc7;
+}
+
+.panel-block {
+  align-items: center;
+  color: #363636;
+  display: flex;
+  justify-content: flex-start;
+  padding: 0.5em 0.75em;
+}
+
+.panel-block input[type="checkbox"] {
+  margin-right: 0.75em;
+}
+
+.panel-block > .control {
+  flex-grow: 1;
+  flex-shrink: 1;
+  width: 100%;
+}
+
+.panel-block.is-wrapped {
+  flex-wrap: wrap;
+}
+
+.panel-block.is-active {
+  border-left-color: #485fc7;
+  color: #363636;
+}
+
+.panel-block.is-active .panel-icon {
+  color: #485fc7;
+}
+
+.panel-block:last-child {
+  border-bottom-left-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+
+a.panel-block,
+label.panel-block {
+  cursor: pointer;
+}
+
+a.panel-block:hover,
+label.panel-block:hover {
+  background-color: #f5f5f5;
+}
+
+.panel-icon {
+  display: inline-block;
+  font-size: 14px;
+  height: 1em;
+  line-height: 1em;
+  text-align: center;
+  vertical-align: top;
+  width: 1em;
+  color: #7a7a7a;
+  margin-right: 0.75em;
+}
+
+.panel-icon .fa {
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.tabs {
+  -webkit-overflow-scrolling: touch;
+  align-items: stretch;
+  display: flex;
+  font-size: 1rem;
+  justify-content: space-between;
+  overflow: hidden;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.tabs a {
+  align-items: center;
+  border-bottom-color: #dbdbdb;
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  color: #4a4a4a;
+  display: flex;
+  justify-content: center;
+  margin-bottom: -1px;
+  padding: 0.5em 1em;
+  vertical-align: top;
+}
+
+.tabs a:hover {
+  border-bottom-color: #363636;
+  color: #363636;
+}
+
+.tabs li {
+  display: block;
+}
+
+.tabs li.is-active a {
+  border-bottom-color: #485fc7;
+  color: #485fc7;
+}
+
+.tabs ul {
+  align-items: center;
+  border-bottom-color: #dbdbdb;
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  display: flex;
+  flex-grow: 1;
+  flex-shrink: 0;
+  justify-content: flex-start;
+}
+
+.tabs ul.is-left {
+  padding-right: 0.75em;
+}
+
+.tabs ul.is-center {
+  flex: none;
+  justify-content: center;
+  padding-left: 0.75em;
+  padding-right: 0.75em;
+}
+
+.tabs ul.is-right {
+  justify-content: flex-end;
+  padding-left: 0.75em;
+}
+
+.tabs .icon:first-child {
+  margin-right: 0.5em;
+}
+
+.tabs .icon:last-child {
+  margin-left: 0.5em;
+}
+
+.tabs.is-centered ul {
+  justify-content: center;
+}
+
+.tabs.is-right ul {
+  justify-content: flex-end;
+}
+
+.tabs.is-boxed a {
+  border: 1px solid transparent;
+  border-radius: 4px 4px 0 0;
+}
+
+.tabs.is-boxed a:hover {
+  background-color: #f5f5f5;
+  border-bottom-color: #dbdbdb;
+}
+
+.tabs.is-boxed li.is-active a {
+  background-color: #fff;
+  border-color: #dbdbdb;
+  border-bottom-color: transparent !important;
+}
+
+.tabs.is-fullwidth li {
+  flex-grow: 1;
+  flex-shrink: 0;
+}
+
+.tabs.is-toggle a {
+  border-color: #dbdbdb;
+  border-style: solid;
+  border-width: 1px;
+  margin-bottom: 0;
+  position: relative;
+}
+
+.tabs.is-toggle a:hover {
+  background-color: #f5f5f5;
+  border-color: #b5b5b5;
+  z-index: 2;
+}
+
+.tabs.is-toggle li + li {
+  margin-left: -1px;
+}
+
+.tabs.is-toggle li:first-child a {
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+
+.tabs.is-toggle li:last-child a {
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.tabs.is-toggle li.is-active a {
+  background-color: #485fc7;
+  border-color: #485fc7;
+  color: #fff;
+  z-index: 1;
+}
+
+.tabs.is-toggle ul {
+  border-bottom: none;
+}
+
+.tabs.is-toggle.is-toggle-rounded li:first-child a {
+  border-bottom-left-radius: 9999px;
+  border-top-left-radius: 9999px;
+  padding-left: 1.25em;
+}
+
+.tabs.is-toggle.is-toggle-rounded li:last-child a {
+  border-bottom-right-radius: 9999px;
+  border-top-right-radius: 9999px;
+  padding-right: 1.25em;
+}
+
+.tabs.is-small {
+  font-size: 0.75rem;
+}
+
+.tabs.is-medium {
+  font-size: 1.25rem;
+}
+
+.tabs.is-large {
+  font-size: 1.5rem;
+}
+
+.column {
+  display: block;
+  flex-basis: 0;
+  flex-grow: 1;
+  flex-shrink: 1;
+  padding: 0.75rem;
+}
+
+.columns.is-mobile > .column.is-narrow {
+  flex: none;
+  width: unset;
+}
+
+.columns.is-mobile > .column.is-full {
+  flex: none;
+  width: 100%;
+}
+
+.columns.is-mobile > .column.is-three-quarters {
+  flex: none;
+  width: 75%;
+}
+
+.columns.is-mobile > .column.is-two-thirds {
+  flex: none;
+  width: 66.6666%;
+}
+
+.columns.is-mobile > .column.is-half {
+  flex: none;
+  width: 50%;
+}
+
+.columns.is-mobile > .column.is-one-third {
+  flex: none;
+  width: 33.3333%;
+}
+
+.columns.is-mobile > .column.is-one-quarter {
+  flex: none;
+  width: 25%;
+}
+
+.columns.is-mobile > .column.is-one-fifth {
+  flex: none;
+  width: 20%;
+}
+
+.columns.is-mobile > .column.is-two-fifths {
+  flex: none;
+  width: 40%;
+}
+
+.columns.is-mobile > .column.is-three-fifths {
+  flex: none;
+  width: 60%;
+}
+
+.columns.is-mobile > .column.is-four-fifths {
+  flex: none;
+  width: 80%;
+}
+
+.columns.is-mobile > .column.is-offset-three-quarters {
+  margin-left: 75%;
+}
+
+.columns.is-mobile > .column.is-offset-two-thirds {
+  margin-left: 66.6666%;
+}
+
+.columns.is-mobile > .column.is-offset-half {
+  margin-left: 50%;
+}
+
+.columns.is-mobile > .column.is-offset-one-third {
+  margin-left: 33.3333%;
+}
+
+.columns.is-mobile > .column.is-offset-one-quarter {
+  margin-left: 25%;
+}
+
+.columns.is-mobile > .column.is-offset-one-fifth {
+  margin-left: 20%;
+}
+
+.columns.is-mobile > .column.is-offset-two-fifths {
+  margin-left: 40%;
+}
+
+.columns.is-mobile > .column.is-offset-three-fifths {
+  margin-left: 60%;
+}
+
+.columns.is-mobile > .column.is-offset-four-fifths {
+  margin-left: 80%;
+}
+
+.columns.is-mobile > .column.is-0 {
+  flex: none;
+  width: 0%;
+}
+
+.columns.is-mobile > .column.is-offset-0 {
+  margin-left: 0;
+}
+
+.columns.is-mobile > .column.is-1 {
+  flex: none;
+  width: 8.33333%;
+}
+
+.columns.is-mobile > .column.is-offset-1 {
+  margin-left: 8.33333%;
+}
+
+.columns.is-mobile > .column.is-2 {
+  flex: none;
+  width: 16.66667%;
+}
+
+.columns.is-mobile > .column.is-offset-2 {
+  margin-left: 16.66667%;
+}
+
+.columns.is-mobile > .column.is-3 {
+  flex: none;
+  width: 25%;
+}
+
+.columns.is-mobile > .column.is-offset-3 {
+  margin-left: 25%;
+}
+
+.columns.is-mobile > .column.is-4 {
+  flex: none;
+  width: 33.33333%;
+}
+
+.columns.is-mobile > .column.is-offset-4 {
+  margin-left: 33.33333%;
+}
+
+.columns.is-mobile > .column.is-5 {
+  flex: none;
+  width: 41.66667%;
+}
+
+.columns.is-mobile > .column.is-offset-5 {
+  margin-left: 41.66667%;
+}
+
+.columns.is-mobile > .column.is-6 {
+  flex: none;
+  width: 50%;
+}
+
+.columns.is-mobile > .column.is-offset-6 {
+  margin-left: 50%;
+}
+
+.columns.is-mobile > .column.is-7 {
+  flex: none;
+  width: 58.33333%;
+}
+
+.columns.is-mobile > .column.is-offset-7 {
+  margin-left: 58.33333%;
+}
+
+.columns.is-mobile > .column.is-8 {
+  flex: none;
+  width: 66.66667%;
+}
+
+.columns.is-mobile > .column.is-offset-8 {
+  margin-left: 66.66667%;
+}
+
+.columns.is-mobile > .column.is-9 {
+  flex: none;
+  width: 75%;
+}
+
+.columns.is-mobile > .column.is-offset-9 {
+  margin-left: 75%;
+}
+
+.columns.is-mobile > .column.is-10 {
+  flex: none;
+  width: 83.33333%;
+}
+
+.columns.is-mobile > .column.is-offset-10 {
+  margin-left: 83.33333%;
+}
+
+.columns.is-mobile > .column.is-11 {
+  flex: none;
+  width: 91.66667%;
+}
+
+.columns.is-mobile > .column.is-offset-11 {
+  margin-left: 91.66667%;
+}
+
+.columns.is-mobile > .column.is-12 {
+  flex: none;
+  width: 100%;
+}
+
+.columns.is-mobile > .column.is-offset-12 {
+  margin-left: 100%;
+}
+
+@media screen and (max-width: 768px) {
+  .column.is-narrow-mobile {
+    flex: none;
+    width: unset;
+  }
+
+  .column.is-full-mobile {
+    flex: none;
+    width: 100%;
+  }
+
+  .column.is-three-quarters-mobile {
+    flex: none;
+    width: 75%;
+  }
+
+  .column.is-two-thirds-mobile {
+    flex: none;
+    width: 66.6666%;
+  }
+
+  .column.is-half-mobile {
+    flex: none;
+    width: 50%;
+  }
+
+  .column.is-one-third-mobile {
+    flex: none;
+    width: 33.3333%;
+  }
+
+  .column.is-one-quarter-mobile {
+    flex: none;
+    width: 25%;
+  }
+
+  .column.is-one-fifth-mobile {
+    flex: none;
+    width: 20%;
+  }
+
+  .column.is-two-fifths-mobile {
+    flex: none;
+    width: 40%;
+  }
+
+  .column.is-three-fifths-mobile {
+    flex: none;
+    width: 60%;
+  }
+
+  .column.is-four-fifths-mobile {
+    flex: none;
+    width: 80%;
+  }
+
+  .column.is-offset-three-quarters-mobile {
+    margin-left: 75%;
+  }
+
+  .column.is-offset-two-thirds-mobile {
+    margin-left: 66.6666%;
+  }
+
+  .column.is-offset-half-mobile {
+    margin-left: 50%;
+  }
+
+  .column.is-offset-one-third-mobile {
+    margin-left: 33.3333%;
+  }
+
+  .column.is-offset-one-quarter-mobile {
+    margin-left: 25%;
+  }
+
+  .column.is-offset-one-fifth-mobile {
+    margin-left: 20%;
+  }
+
+  .column.is-offset-two-fifths-mobile {
+    margin-left: 40%;
+  }
+
+  .column.is-offset-three-fifths-mobile {
+    margin-left: 60%;
+  }
+
+  .column.is-offset-four-fifths-mobile {
+    margin-left: 80%;
+  }
+
+  .column.is-0-mobile {
+    flex: none;
+    width: 0%;
+  }
+
+  .column.is-offset-0-mobile {
+    margin-left: 0;
+  }
+
+  .column.is-1-mobile {
+    flex: none;
+    width: 8.33333%;
+  }
+
+  .column.is-offset-1-mobile {
+    margin-left: 8.33333%;
+  }
+
+  .column.is-2-mobile {
+    flex: none;
+    width: 16.66667%;
+  }
+
+  .column.is-offset-2-mobile {
+    margin-left: 16.66667%;
+  }
+
+  .column.is-3-mobile {
+    flex: none;
+    width: 25%;
+  }
+
+  .column.is-offset-3-mobile {
+    margin-left: 25%;
+  }
+
+  .column.is-4-mobile {
+    flex: none;
+    width: 33.33333%;
+  }
+
+  .column.is-offset-4-mobile {
+    margin-left: 33.33333%;
+  }
+
+  .column.is-5-mobile {
+    flex: none;
+    width: 41.66667%;
+  }
+
+  .column.is-offset-5-mobile {
+    margin-left: 41.66667%;
+  }
+
+  .column.is-6-mobile {
+    flex: none;
+    width: 50%;
+  }
+
+  .column.is-offset-6-mobile {
+    margin-left: 50%;
+  }
+
+  .column.is-7-mobile {
+    flex: none;
+    width: 58.33333%;
+  }
+
+  .column.is-offset-7-mobile {
+    margin-left: 58.33333%;
+  }
+
+  .column.is-8-mobile {
+    flex: none;
+    width: 66.66667%;
+  }
+
+  .column.is-offset-8-mobile {
+    margin-left: 66.66667%;
+  }
+
+  .column.is-9-mobile {
+    flex: none;
+    width: 75%;
+  }
+
+  .column.is-offset-9-mobile {
+    margin-left: 75%;
+  }
+
+  .column.is-10-mobile {
+    flex: none;
+    width: 83.33333%;
+  }
+
+  .column.is-offset-10-mobile {
+    margin-left: 83.33333%;
+  }
+
+  .column.is-11-mobile {
+    flex: none;
+    width: 91.66667%;
+  }
+
+  .column.is-offset-11-mobile {
+    margin-left: 91.66667%;
+  }
+
+  .column.is-12-mobile {
+    flex: none;
+    width: 100%;
+  }
+
+  .column.is-offset-12-mobile {
+    margin-left: 100%;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .column.is-narrow,
+  .column.is-narrow-tablet {
+    flex: none;
+    width: unset;
+  }
+
+  .column.is-full,
+  .column.is-full-tablet {
+    flex: none;
+    width: 100%;
+  }
+
+  .column.is-three-quarters,
+  .column.is-three-quarters-tablet {
+    flex: none;
+    width: 75%;
+  }
+
+  .column.is-two-thirds,
+  .column.is-two-thirds-tablet {
+    flex: none;
+    width: 66.6666%;
+  }
+
+  .column.is-half,
+  .column.is-half-tablet {
+    flex: none;
+    width: 50%;
+  }
+
+  .column.is-one-third,
+  .column.is-one-third-tablet {
+    flex: none;
+    width: 33.3333%;
+  }
+
+  .column.is-one-quarter,
+  .column.is-one-quarter-tablet {
+    flex: none;
+    width: 25%;
+  }
+
+  .column.is-one-fifth,
+  .column.is-one-fifth-tablet {
+    flex: none;
+    width: 20%;
+  }
+
+  .column.is-two-fifths,
+  .column.is-two-fifths-tablet {
+    flex: none;
+    width: 40%;
+  }
+
+  .column.is-three-fifths,
+  .column.is-three-fifths-tablet {
+    flex: none;
+    width: 60%;
+  }
+
+  .column.is-four-fifths,
+  .column.is-four-fifths-tablet {
+    flex: none;
+    width: 80%;
+  }
+
+  .column.is-offset-three-quarters,
+  .column.is-offset-three-quarters-tablet {
+    margin-left: 75%;
+  }
+
+  .column.is-offset-two-thirds,
+  .column.is-offset-two-thirds-tablet {
+    margin-left: 66.6666%;
+  }
+
+  .column.is-offset-half,
+  .column.is-offset-half-tablet {
+    margin-left: 50%;
+  }
+
+  .column.is-offset-one-third,
+  .column.is-offset-one-third-tablet {
+    margin-left: 33.3333%;
+  }
+
+  .column.is-offset-one-quarter,
+  .column.is-offset-one-quarter-tablet {
+    margin-left: 25%;
+  }
+
+  .column.is-offset-one-fifth,
+  .column.is-offset-one-fifth-tablet {
+    margin-left: 20%;
+  }
+
+  .column.is-offset-two-fifths,
+  .column.is-offset-two-fifths-tablet {
+    margin-left: 40%;
+  }
+
+  .column.is-offset-three-fifths,
+  .column.is-offset-three-fifths-tablet {
+    margin-left: 60%;
+  }
+
+  .column.is-offset-four-fifths,
+  .column.is-offset-four-fifths-tablet {
+    margin-left: 80%;
+  }
+
+  .column.is-0,
+  .column.is-0-tablet {
+    flex: none;
+    width: 0%;
+  }
+
+  .column.is-offset-0,
+  .column.is-offset-0-tablet {
+    margin-left: 0;
+  }
+
+  .column.is-1,
+  .column.is-1-tablet {
+    flex: none;
+    width: 8.33333%;
+  }
+
+  .column.is-offset-1,
+  .column.is-offset-1-tablet {
+    margin-left: 8.33333%;
+  }
+
+  .column.is-2,
+  .column.is-2-tablet {
+    flex: none;
+    width: 16.66667%;
+  }
+
+  .column.is-offset-2,
+  .column.is-offset-2-tablet {
+    margin-left: 16.66667%;
+  }
+
+  .column.is-3,
+  .column.is-3-tablet {
+    flex: none;
+    width: 25%;
+  }
+
+  .column.is-offset-3,
+  .column.is-offset-3-tablet {
+    margin-left: 25%;
+  }
+
+  .column.is-4,
+  .column.is-4-tablet {
+    flex: none;
+    width: 33.33333%;
+  }
+
+  .column.is-offset-4,
+  .column.is-offset-4-tablet {
+    margin-left: 33.33333%;
+  }
+
+  .column.is-5,
+  .column.is-5-tablet {
+    flex: none;
+    width: 41.66667%;
+  }
+
+  .column.is-offset-5,
+  .column.is-offset-5-tablet {
+    margin-left: 41.66667%;
+  }
+
+  .column.is-6,
+  .column.is-6-tablet {
+    flex: none;
+    width: 50%;
+  }
+
+  .column.is-offset-6,
+  .column.is-offset-6-tablet {
+    margin-left: 50%;
+  }
+
+  .column.is-7,
+  .column.is-7-tablet {
+    flex: none;
+    width: 58.33333%;
+  }
+
+  .column.is-offset-7,
+  .column.is-offset-7-tablet {
+    margin-left: 58.33333%;
+  }
+
+  .column.is-8,
+  .column.is-8-tablet {
+    flex: none;
+    width: 66.66667%;
+  }
+
+  .column.is-offset-8,
+  .column.is-offset-8-tablet {
+    margin-left: 66.66667%;
+  }
+
+  .column.is-9,
+  .column.is-9-tablet {
+    flex: none;
+    width: 75%;
+  }
+
+  .column.is-offset-9,
+  .column.is-offset-9-tablet {
+    margin-left: 75%;
+  }
+
+  .column.is-10,
+  .column.is-10-tablet {
+    flex: none;
+    width: 83.33333%;
+  }
+
+  .column.is-offset-10,
+  .column.is-offset-10-tablet {
+    margin-left: 83.33333%;
+  }
+
+  .column.is-11,
+  .column.is-11-tablet {
+    flex: none;
+    width: 91.66667%;
+  }
+
+  .column.is-offset-11,
+  .column.is-offset-11-tablet {
+    margin-left: 91.66667%;
+  }
+
+  .column.is-12,
+  .column.is-12-tablet {
+    flex: none;
+    width: 100%;
+  }
+
+  .column.is-offset-12,
+  .column.is-offset-12-tablet {
+    margin-left: 100%;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .column.is-narrow-touch {
+    flex: none;
+    width: unset;
+  }
+
+  .column.is-full-touch {
+    flex: none;
+    width: 100%;
+  }
+
+  .column.is-three-quarters-touch {
+    flex: none;
+    width: 75%;
+  }
+
+  .column.is-two-thirds-touch {
+    flex: none;
+    width: 66.6666%;
+  }
+
+  .column.is-half-touch {
+    flex: none;
+    width: 50%;
+  }
+
+  .column.is-one-third-touch {
+    flex: none;
+    width: 33.3333%;
+  }
+
+  .column.is-one-quarter-touch {
+    flex: none;
+    width: 25%;
+  }
+
+  .column.is-one-fifth-touch {
+    flex: none;
+    width: 20%;
+  }
+
+  .column.is-two-fifths-touch {
+    flex: none;
+    width: 40%;
+  }
+
+  .column.is-three-fifths-touch {
+    flex: none;
+    width: 60%;
+  }
+
+  .column.is-four-fifths-touch {
+    flex: none;
+    width: 80%;
+  }
+
+  .column.is-offset-three-quarters-touch {
+    margin-left: 75%;
+  }
+
+  .column.is-offset-two-thirds-touch {
+    margin-left: 66.6666%;
+  }
+
+  .column.is-offset-half-touch {
+    margin-left: 50%;
+  }
+
+  .column.is-offset-one-third-touch {
+    margin-left: 33.3333%;
+  }
+
+  .column.is-offset-one-quarter-touch {
+    margin-left: 25%;
+  }
+
+  .column.is-offset-one-fifth-touch {
+    margin-left: 20%;
+  }
+
+  .column.is-offset-two-fifths-touch {
+    margin-left: 40%;
+  }
+
+  .column.is-offset-three-fifths-touch {
+    margin-left: 60%;
+  }
+
+  .column.is-offset-four-fifths-touch {
+    margin-left: 80%;
+  }
+
+  .column.is-0-touch {
+    flex: none;
+    width: 0%;
+  }
+
+  .column.is-offset-0-touch {
+    margin-left: 0;
+  }
+
+  .column.is-1-touch {
+    flex: none;
+    width: 8.33333%;
+  }
+
+  .column.is-offset-1-touch {
+    margin-left: 8.33333%;
+  }
+
+  .column.is-2-touch {
+    flex: none;
+    width: 16.66667%;
+  }
+
+  .column.is-offset-2-touch {
+    margin-left: 16.66667%;
+  }
+
+  .column.is-3-touch {
+    flex: none;
+    width: 25%;
+  }
+
+  .column.is-offset-3-touch {
+    margin-left: 25%;
+  }
+
+  .column.is-4-touch {
+    flex: none;
+    width: 33.33333%;
+  }
+
+  .column.is-offset-4-touch {
+    margin-left: 33.33333%;
+  }
+
+  .column.is-5-touch {
+    flex: none;
+    width: 41.66667%;
+  }
+
+  .column.is-offset-5-touch {
+    margin-left: 41.66667%;
+  }
+
+  .column.is-6-touch {
+    flex: none;
+    width: 50%;
+  }
+
+  .column.is-offset-6-touch {
+    margin-left: 50%;
+  }
+
+  .column.is-7-touch {
+    flex: none;
+    width: 58.33333%;
+  }
+
+  .column.is-offset-7-touch {
+    margin-left: 58.33333%;
+  }
+
+  .column.is-8-touch {
+    flex: none;
+    width: 66.66667%;
+  }
+
+  .column.is-offset-8-touch {
+    margin-left: 66.66667%;
+  }
+
+  .column.is-9-touch {
+    flex: none;
+    width: 75%;
+  }
+
+  .column.is-offset-9-touch {
+    margin-left: 75%;
+  }
+
+  .column.is-10-touch {
+    flex: none;
+    width: 83.33333%;
+  }
+
+  .column.is-offset-10-touch {
+    margin-left: 83.33333%;
+  }
+
+  .column.is-11-touch {
+    flex: none;
+    width: 91.66667%;
+  }
+
+  .column.is-offset-11-touch {
+    margin-left: 91.66667%;
+  }
+
+  .column.is-12-touch {
+    flex: none;
+    width: 100%;
+  }
+
+  .column.is-offset-12-touch {
+    margin-left: 100%;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .column.is-narrow-desktop {
+    flex: none;
+    width: unset;
+  }
+
+  .column.is-full-desktop {
+    flex: none;
+    width: 100%;
+  }
+
+  .column.is-three-quarters-desktop {
+    flex: none;
+    width: 75%;
+  }
+
+  .column.is-two-thirds-desktop {
+    flex: none;
+    width: 66.6666%;
+  }
+
+  .column.is-half-desktop {
+    flex: none;
+    width: 50%;
+  }
+
+  .column.is-one-third-desktop {
+    flex: none;
+    width: 33.3333%;
+  }
+
+  .column.is-one-quarter-desktop {
+    flex: none;
+    width: 25%;
+  }
+
+  .column.is-one-fifth-desktop {
+    flex: none;
+    width: 20%;
+  }
+
+  .column.is-two-fifths-desktop {
+    flex: none;
+    width: 40%;
+  }
+
+  .column.is-three-fifths-desktop {
+    flex: none;
+    width: 60%;
+  }
+
+  .column.is-four-fifths-desktop {
+    flex: none;
+    width: 80%;
+  }
+
+  .column.is-offset-three-quarters-desktop {
+    margin-left: 75%;
+  }
+
+  .column.is-offset-two-thirds-desktop {
+    margin-left: 66.6666%;
+  }
+
+  .column.is-offset-half-desktop {
+    margin-left: 50%;
+  }
+
+  .column.is-offset-one-third-desktop {
+    margin-left: 33.3333%;
+  }
+
+  .column.is-offset-one-quarter-desktop {
+    margin-left: 25%;
+  }
+
+  .column.is-offset-one-fifth-desktop {
+    margin-left: 20%;
+  }
+
+  .column.is-offset-two-fifths-desktop {
+    margin-left: 40%;
+  }
+
+  .column.is-offset-three-fifths-desktop {
+    margin-left: 60%;
+  }
+
+  .column.is-offset-four-fifths-desktop {
+    margin-left: 80%;
+  }
+
+  .column.is-0-desktop {
+    flex: none;
+    width: 0%;
+  }
+
+  .column.is-offset-0-desktop {
+    margin-left: 0;
+  }
+
+  .column.is-1-desktop {
+    flex: none;
+    width: 8.33333%;
+  }
+
+  .column.is-offset-1-desktop {
+    margin-left: 8.33333%;
+  }
+
+  .column.is-2-desktop {
+    flex: none;
+    width: 16.66667%;
+  }
+
+  .column.is-offset-2-desktop {
+    margin-left: 16.66667%;
+  }
+
+  .column.is-3-desktop {
+    flex: none;
+    width: 25%;
+  }
+
+  .column.is-offset-3-desktop {
+    margin-left: 25%;
+  }
+
+  .column.is-4-desktop {
+    flex: none;
+    width: 33.33333%;
+  }
+
+  .column.is-offset-4-desktop {
+    margin-left: 33.33333%;
+  }
+
+  .column.is-5-desktop {
+    flex: none;
+    width: 41.66667%;
+  }
+
+  .column.is-offset-5-desktop {
+    margin-left: 41.66667%;
+  }
+
+  .column.is-6-desktop {
+    flex: none;
+    width: 50%;
+  }
+
+  .column.is-offset-6-desktop {
+    margin-left: 50%;
+  }
+
+  .column.is-7-desktop {
+    flex: none;
+    width: 58.33333%;
+  }
+
+  .column.is-offset-7-desktop {
+    margin-left: 58.33333%;
+  }
+
+  .column.is-8-desktop {
+    flex: none;
+    width: 66.66667%;
+  }
+
+  .column.is-offset-8-desktop {
+    margin-left: 66.66667%;
+  }
+
+  .column.is-9-desktop {
+    flex: none;
+    width: 75%;
+  }
+
+  .column.is-offset-9-desktop {
+    margin-left: 75%;
+  }
+
+  .column.is-10-desktop {
+    flex: none;
+    width: 83.33333%;
+  }
+
+  .column.is-offset-10-desktop {
+    margin-left: 83.33333%;
+  }
+
+  .column.is-11-desktop {
+    flex: none;
+    width: 91.66667%;
+  }
+
+  .column.is-offset-11-desktop {
+    margin-left: 91.66667%;
+  }
+
+  .column.is-12-desktop {
+    flex: none;
+    width: 100%;
+  }
+
+  .column.is-offset-12-desktop {
+    margin-left: 100%;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .column.is-narrow-widescreen {
+    flex: none;
+    width: unset;
+  }
+
+  .column.is-full-widescreen {
+    flex: none;
+    width: 100%;
+  }
+
+  .column.is-three-quarters-widescreen {
+    flex: none;
+    width: 75%;
+  }
+
+  .column.is-two-thirds-widescreen {
+    flex: none;
+    width: 66.6666%;
+  }
+
+  .column.is-half-widescreen {
+    flex: none;
+    width: 50%;
+  }
+
+  .column.is-one-third-widescreen {
+    flex: none;
+    width: 33.3333%;
+  }
+
+  .column.is-one-quarter-widescreen {
+    flex: none;
+    width: 25%;
+  }
+
+  .column.is-one-fifth-widescreen {
+    flex: none;
+    width: 20%;
+  }
+
+  .column.is-two-fifths-widescreen {
+    flex: none;
+    width: 40%;
+  }
+
+  .column.is-three-fifths-widescreen {
+    flex: none;
+    width: 60%;
+  }
+
+  .column.is-four-fifths-widescreen {
+    flex: none;
+    width: 80%;
+  }
+
+  .column.is-offset-three-quarters-widescreen {
+    margin-left: 75%;
+  }
+
+  .column.is-offset-two-thirds-widescreen {
+    margin-left: 66.6666%;
+  }
+
+  .column.is-offset-half-widescreen {
+    margin-left: 50%;
+  }
+
+  .column.is-offset-one-third-widescreen {
+    margin-left: 33.3333%;
+  }
+
+  .column.is-offset-one-quarter-widescreen {
+    margin-left: 25%;
+  }
+
+  .column.is-offset-one-fifth-widescreen {
+    margin-left: 20%;
+  }
+
+  .column.is-offset-two-fifths-widescreen {
+    margin-left: 40%;
+  }
+
+  .column.is-offset-three-fifths-widescreen {
+    margin-left: 60%;
+  }
+
+  .column.is-offset-four-fifths-widescreen {
+    margin-left: 80%;
+  }
+
+  .column.is-0-widescreen {
+    flex: none;
+    width: 0%;
+  }
+
+  .column.is-offset-0-widescreen {
+    margin-left: 0;
+  }
+
+  .column.is-1-widescreen {
+    flex: none;
+    width: 8.33333%;
+  }
+
+  .column.is-offset-1-widescreen {
+    margin-left: 8.33333%;
+  }
+
+  .column.is-2-widescreen {
+    flex: none;
+    width: 16.66667%;
+  }
+
+  .column.is-offset-2-widescreen {
+    margin-left: 16.66667%;
+  }
+
+  .column.is-3-widescreen {
+    flex: none;
+    width: 25%;
+  }
+
+  .column.is-offset-3-widescreen {
+    margin-left: 25%;
+  }
+
+  .column.is-4-widescreen {
+    flex: none;
+    width: 33.33333%;
+  }
+
+  .column.is-offset-4-widescreen {
+    margin-left: 33.33333%;
+  }
+
+  .column.is-5-widescreen {
+    flex: none;
+    width: 41.66667%;
+  }
+
+  .column.is-offset-5-widescreen {
+    margin-left: 41.66667%;
+  }
+
+  .column.is-6-widescreen {
+    flex: none;
+    width: 50%;
+  }
+
+  .column.is-offset-6-widescreen {
+    margin-left: 50%;
+  }
+
+  .column.is-7-widescreen {
+    flex: none;
+    width: 58.33333%;
+  }
+
+  .column.is-offset-7-widescreen {
+    margin-left: 58.33333%;
+  }
+
+  .column.is-8-widescreen {
+    flex: none;
+    width: 66.66667%;
+  }
+
+  .column.is-offset-8-widescreen {
+    margin-left: 66.66667%;
+  }
+
+  .column.is-9-widescreen {
+    flex: none;
+    width: 75%;
+  }
+
+  .column.is-offset-9-widescreen {
+    margin-left: 75%;
+  }
+
+  .column.is-10-widescreen {
+    flex: none;
+    width: 83.33333%;
+  }
+
+  .column.is-offset-10-widescreen {
+    margin-left: 83.33333%;
+  }
+
+  .column.is-11-widescreen {
+    flex: none;
+    width: 91.66667%;
+  }
+
+  .column.is-offset-11-widescreen {
+    margin-left: 91.66667%;
+  }
+
+  .column.is-12-widescreen {
+    flex: none;
+    width: 100%;
+  }
+
+  .column.is-offset-12-widescreen {
+    margin-left: 100%;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .column.is-narrow-fullhd {
+    flex: none;
+    width: unset;
+  }
+
+  .column.is-full-fullhd {
+    flex: none;
+    width: 100%;
+  }
+
+  .column.is-three-quarters-fullhd {
+    flex: none;
+    width: 75%;
+  }
+
+  .column.is-two-thirds-fullhd {
+    flex: none;
+    width: 66.6666%;
+  }
+
+  .column.is-half-fullhd {
+    flex: none;
+    width: 50%;
+  }
+
+  .column.is-one-third-fullhd {
+    flex: none;
+    width: 33.3333%;
+  }
+
+  .column.is-one-quarter-fullhd {
+    flex: none;
+    width: 25%;
+  }
+
+  .column.is-one-fifth-fullhd {
+    flex: none;
+    width: 20%;
+  }
+
+  .column.is-two-fifths-fullhd {
+    flex: none;
+    width: 40%;
+  }
+
+  .column.is-three-fifths-fullhd {
+    flex: none;
+    width: 60%;
+  }
+
+  .column.is-four-fifths-fullhd {
+    flex: none;
+    width: 80%;
+  }
+
+  .column.is-offset-three-quarters-fullhd {
+    margin-left: 75%;
+  }
+
+  .column.is-offset-two-thirds-fullhd {
+    margin-left: 66.6666%;
+  }
+
+  .column.is-offset-half-fullhd {
+    margin-left: 50%;
+  }
+
+  .column.is-offset-one-third-fullhd {
+    margin-left: 33.3333%;
+  }
+
+  .column.is-offset-one-quarter-fullhd {
+    margin-left: 25%;
+  }
+
+  .column.is-offset-one-fifth-fullhd {
+    margin-left: 20%;
+  }
+
+  .column.is-offset-two-fifths-fullhd {
+    margin-left: 40%;
+  }
+
+  .column.is-offset-three-fifths-fullhd {
+    margin-left: 60%;
+  }
+
+  .column.is-offset-four-fifths-fullhd {
+    margin-left: 80%;
+  }
+
+  .column.is-0-fullhd {
+    flex: none;
+    width: 0%;
+  }
+
+  .column.is-offset-0-fullhd {
+    margin-left: 0;
+  }
+
+  .column.is-1-fullhd {
+    flex: none;
+    width: 8.33333%;
+  }
+
+  .column.is-offset-1-fullhd {
+    margin-left: 8.33333%;
+  }
+
+  .column.is-2-fullhd {
+    flex: none;
+    width: 16.66667%;
+  }
+
+  .column.is-offset-2-fullhd {
+    margin-left: 16.66667%;
+  }
+
+  .column.is-3-fullhd {
+    flex: none;
+    width: 25%;
+  }
+
+  .column.is-offset-3-fullhd {
+    margin-left: 25%;
+  }
+
+  .column.is-4-fullhd {
+    flex: none;
+    width: 33.33333%;
+  }
+
+  .column.is-offset-4-fullhd {
+    margin-left: 33.33333%;
+  }
+
+  .column.is-5-fullhd {
+    flex: none;
+    width: 41.66667%;
+  }
+
+  .column.is-offset-5-fullhd {
+    margin-left: 41.66667%;
+  }
+
+  .column.is-6-fullhd {
+    flex: none;
+    width: 50%;
+  }
+
+  .column.is-offset-6-fullhd {
+    margin-left: 50%;
+  }
+
+  .column.is-7-fullhd {
+    flex: none;
+    width: 58.33333%;
+  }
+
+  .column.is-offset-7-fullhd {
+    margin-left: 58.33333%;
+  }
+
+  .column.is-8-fullhd {
+    flex: none;
+    width: 66.66667%;
+  }
+
+  .column.is-offset-8-fullhd {
+    margin-left: 66.66667%;
+  }
+
+  .column.is-9-fullhd {
+    flex: none;
+    width: 75%;
+  }
+
+  .column.is-offset-9-fullhd {
+    margin-left: 75%;
+  }
+
+  .column.is-10-fullhd {
+    flex: none;
+    width: 83.33333%;
+  }
+
+  .column.is-offset-10-fullhd {
+    margin-left: 83.33333%;
+  }
+
+  .column.is-11-fullhd {
+    flex: none;
+    width: 91.66667%;
+  }
+
+  .column.is-offset-11-fullhd {
+    margin-left: 91.66667%;
+  }
+
+  .column.is-12-fullhd {
+    flex: none;
+    width: 100%;
+  }
+
+  .column.is-offset-12-fullhd {
+    margin-left: 100%;
+  }
+}
+
+.columns {
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+  margin-top: -0.75rem;
+}
+
+.columns:last-child {
+  margin-bottom: -0.75rem;
+}
+
+.columns:not(:last-child) {
+  margin-bottom: calc(1.5rem - 0.75rem);
+}
+
+.columns.is-centered {
+  justify-content: center;
+}
+
+.columns.is-gapless {
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+}
+
+.columns.is-gapless > .column {
+  margin: 0;
+  padding: 0 !important;
+}
+
+.columns.is-gapless:not(:last-child) {
+  margin-bottom: 1.5rem;
+}
+
+.columns.is-gapless:last-child {
+  margin-bottom: 0;
+}
+
+.columns.is-mobile {
+  display: flex;
+}
+
+.columns.is-multiline {
+  flex-wrap: wrap;
+}
+
+.columns.is-vcentered {
+  align-items: center;
+}
+
+@media screen and (min-width: 769px), print {
+  .columns:not(.is-desktop) {
+    display: flex;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .columns.is-desktop {
+    display: flex;
+  }
+}
+
+.columns.is-variable {
+  --columnGap: 0.75rem;
+  margin-left: calc(-1 * var(--columnGap));
+  margin-right: calc(-1 * var(--columnGap));
+}
+
+.columns.is-variable > .column {
+  padding-left: var(--columnGap);
+  padding-right: var(--columnGap);
+}
+
+.columns.is-variable.is-0 {
+  --columnGap: 0rem;
+}
+
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-0-mobile {
+    --columnGap: 0rem;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-0-tablet {
+    --columnGap: 0rem;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-0-tablet-only {
+    --columnGap: 0rem;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-0-touch {
+    --columnGap: 0rem;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-0-desktop {
+    --columnGap: 0rem;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-0-desktop-only {
+    --columnGap: 0rem;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-0-widescreen {
+    --columnGap: 0rem;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-variable.is-0-widescreen-only {
+    --columnGap: 0rem;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .columns.is-variable.is-0-fullhd {
+    --columnGap: 0rem;
+  }
+}
+
+.columns.is-variable.is-1 {
+  --columnGap: 0.25rem;
+}
+
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-1-mobile {
+    --columnGap: 0.25rem;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-1-tablet {
+    --columnGap: 0.25rem;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-1-tablet-only {
+    --columnGap: 0.25rem;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-1-touch {
+    --columnGap: 0.25rem;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-1-desktop {
+    --columnGap: 0.25rem;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-1-desktop-only {
+    --columnGap: 0.25rem;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-1-widescreen {
+    --columnGap: 0.25rem;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-variable.is-1-widescreen-only {
+    --columnGap: 0.25rem;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .columns.is-variable.is-1-fullhd {
+    --columnGap: 0.25rem;
+  }
+}
+
+.columns.is-variable.is-2 {
+  --columnGap: 0.5rem;
+}
+
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-2-mobile {
+    --columnGap: 0.5rem;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-2-tablet {
+    --columnGap: 0.5rem;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-2-tablet-only {
+    --columnGap: 0.5rem;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-2-touch {
+    --columnGap: 0.5rem;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-2-desktop {
+    --columnGap: 0.5rem;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-2-desktop-only {
+    --columnGap: 0.5rem;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-2-widescreen {
+    --columnGap: 0.5rem;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-variable.is-2-widescreen-only {
+    --columnGap: 0.5rem;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .columns.is-variable.is-2-fullhd {
+    --columnGap: 0.5rem;
+  }
+}
+
+.columns.is-variable.is-3 {
+  --columnGap: 0.75rem;
+}
+
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-3-mobile {
+    --columnGap: 0.75rem;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-3-tablet {
+    --columnGap: 0.75rem;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-3-tablet-only {
+    --columnGap: 0.75rem;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-3-touch {
+    --columnGap: 0.75rem;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-3-desktop {
+    --columnGap: 0.75rem;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-3-desktop-only {
+    --columnGap: 0.75rem;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-3-widescreen {
+    --columnGap: 0.75rem;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-variable.is-3-widescreen-only {
+    --columnGap: 0.75rem;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .columns.is-variable.is-3-fullhd {
+    --columnGap: 0.75rem;
+  }
+}
+
+.columns.is-variable.is-4 {
+  --columnGap: 1rem;
+}
+
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-4-mobile {
+    --columnGap: 1rem;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-4-tablet {
+    --columnGap: 1rem;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-4-tablet-only {
+    --columnGap: 1rem;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-4-touch {
+    --columnGap: 1rem;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-4-desktop {
+    --columnGap: 1rem;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-4-desktop-only {
+    --columnGap: 1rem;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-4-widescreen {
+    --columnGap: 1rem;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-variable.is-4-widescreen-only {
+    --columnGap: 1rem;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .columns.is-variable.is-4-fullhd {
+    --columnGap: 1rem;
+  }
+}
+
+.columns.is-variable.is-5 {
+  --columnGap: 1.25rem;
+}
+
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-5-mobile {
+    --columnGap: 1.25rem;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-5-tablet {
+    --columnGap: 1.25rem;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-5-tablet-only {
+    --columnGap: 1.25rem;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-5-touch {
+    --columnGap: 1.25rem;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-5-desktop {
+    --columnGap: 1.25rem;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-5-desktop-only {
+    --columnGap: 1.25rem;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-5-widescreen {
+    --columnGap: 1.25rem;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-variable.is-5-widescreen-only {
+    --columnGap: 1.25rem;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .columns.is-variable.is-5-fullhd {
+    --columnGap: 1.25rem;
+  }
+}
+
+.columns.is-variable.is-6 {
+  --columnGap: 1.5rem;
+}
+
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-6-mobile {
+    --columnGap: 1.5rem;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-6-tablet {
+    --columnGap: 1.5rem;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-6-tablet-only {
+    --columnGap: 1.5rem;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-6-touch {
+    --columnGap: 1.5rem;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-6-desktop {
+    --columnGap: 1.5rem;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-6-desktop-only {
+    --columnGap: 1.5rem;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-6-widescreen {
+    --columnGap: 1.5rem;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-variable.is-6-widescreen-only {
+    --columnGap: 1.5rem;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .columns.is-variable.is-6-fullhd {
+    --columnGap: 1.5rem;
+  }
+}
+
+.columns.is-variable.is-7 {
+  --columnGap: 1.75rem;
+}
+
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-7-mobile {
+    --columnGap: 1.75rem;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-7-tablet {
+    --columnGap: 1.75rem;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-7-tablet-only {
+    --columnGap: 1.75rem;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-7-touch {
+    --columnGap: 1.75rem;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-7-desktop {
+    --columnGap: 1.75rem;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-7-desktop-only {
+    --columnGap: 1.75rem;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-7-widescreen {
+    --columnGap: 1.75rem;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-variable.is-7-widescreen-only {
+    --columnGap: 1.75rem;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .columns.is-variable.is-7-fullhd {
+    --columnGap: 1.75rem;
+  }
+}
+
+.columns.is-variable.is-8 {
+  --columnGap: 2rem;
+}
+
+@media screen and (max-width: 768px) {
+  .columns.is-variable.is-8-mobile {
+    --columnGap: 2rem;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .columns.is-variable.is-8-tablet {
+    --columnGap: 2rem;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-variable.is-8-tablet-only {
+    --columnGap: 2rem;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .columns.is-variable.is-8-touch {
+    --columnGap: 2rem;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .columns.is-variable.is-8-desktop {
+    --columnGap: 2rem;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-variable.is-8-desktop-only {
+    --columnGap: 2rem;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .columns.is-variable.is-8-widescreen {
+    --columnGap: 2rem;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-variable.is-8-widescreen-only {
+    --columnGap: 2rem;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .columns.is-variable.is-8-fullhd {
+    --columnGap: 2rem;
+  }
+}
+
+.tile {
+  align-items: stretch;
+  display: block;
+  flex-basis: 0;
+  flex-grow: 1;
+  flex-shrink: 1;
+  min-height: -webkit-min-content;
+  min-height: -moz-min-content;
+  min-height: min-content;
+}
+
+.tile.is-ancestor {
+  margin-left: -0.75rem;
+  margin-right: -0.75rem;
+  margin-top: -0.75rem;
+}
+
+.tile.is-ancestor:last-child {
+  margin-bottom: -0.75rem;
+}
+
+.tile.is-ancestor:not(:last-child) {
+  margin-bottom: 0.75rem;
+}
+
+.tile.is-child {
+  margin: 0 !important;
+}
+
+.tile.is-parent {
+  padding: 0.75rem;
+}
+
+.tile.is-vertical {
+  flex-direction: column;
+}
+
+.tile.is-vertical > .tile.is-child:not(:last-child) {
+  margin-bottom: 1.5rem !important;
+}
+
+@media screen and (min-width: 769px), print {
+  .tile:not(.is-child) {
+    display: flex;
+  }
+
+  .tile.is-1 {
+    flex: none;
+    width: 8.33333%;
+  }
+
+  .tile.is-2 {
+    flex: none;
+    width: 16.66667%;
+  }
+
+  .tile.is-3 {
+    flex: none;
+    width: 25%;
+  }
+
+  .tile.is-4 {
+    flex: none;
+    width: 33.33333%;
+  }
+
+  .tile.is-5 {
+    flex: none;
+    width: 41.66667%;
+  }
+
+  .tile.is-6 {
+    flex: none;
+    width: 50%;
+  }
+
+  .tile.is-7 {
+    flex: none;
+    width: 58.33333%;
+  }
+
+  .tile.is-8 {
+    flex: none;
+    width: 66.66667%;
+  }
+
+  .tile.is-9 {
+    flex: none;
+    width: 75%;
+  }
+
+  .tile.is-10 {
+    flex: none;
+    width: 83.33333%;
+  }
+
+  .tile.is-11 {
+    flex: none;
+    width: 91.66667%;
+  }
+
+  .tile.is-12 {
+    flex: none;
+    width: 100%;
+  }
+}
+
+.has-text-white {
+  color: #fff !important;
+}
+
+a.has-text-white:focus,
+a.has-text-white:hover {
+  color: #e6e6e6 !important;
+}
+
+.has-background-white {
+  background-color: #fff !important;
+}
+
+.has-text-black {
+  color: #0a0a0a !important;
+}
+
+a.has-text-black:focus,
+a.has-text-black:hover {
+  color: #000 !important;
+}
+
+.has-background-black {
+  background-color: #0a0a0a !important;
+}
+
+.has-text-light {
+  color: #f5f5f5 !important;
+}
+
+a.has-text-light:focus,
+a.has-text-light:hover {
+  color: #dbdbdb !important;
+}
+
+.has-background-light {
+  background-color: #f5f5f5 !important;
+}
+
+.has-text-dark {
+  color: #363636 !important;
+}
+
+a.has-text-dark:focus,
+a.has-text-dark:hover {
+  color: #1c1c1c !important;
+}
+
+.has-background-dark {
+  background-color: #363636 !important;
+}
+
+.has-text-primary {
+  color: #00d1b2 !important;
+}
+
+a.has-text-primary:focus,
+a.has-text-primary:hover {
+  color: #009e86 !important;
+}
+
+.has-background-primary {
+  background-color: #00d1b2 !important;
+}
+
+.has-text-primary-light {
+  color: #ebfffc !important;
+}
+
+a.has-text-primary-light:focus,
+a.has-text-primary-light:hover {
+  color: #b8fff4 !important;
+}
+
+.has-background-primary-light {
+  background-color: #ebfffc !important;
+}
+
+.has-text-primary-dark {
+  color: #00947e !important;
+}
+
+a.has-text-primary-dark:focus,
+a.has-text-primary-dark:hover {
+  color: #00c7a9 !important;
+}
+
+.has-background-primary-dark {
+  background-color: #00947e !important;
+}
+
+.has-text-link {
+  color: #485fc7 !important;
+}
+
+a.has-text-link:focus,
+a.has-text-link:hover {
+  color: #3449a8 !important;
+}
+
+.has-background-link {
+  background-color: #485fc7 !important;
+}
+
+.has-text-link-light {
+  color: #eff1fa !important;
+}
+
+a.has-text-link-light:focus,
+a.has-text-link-light:hover {
+  color: #c8cfee !important;
+}
+
+.has-background-link-light {
+  background-color: #eff1fa !important;
+}
+
+.has-text-link-dark {
+  color: #3850b7 !important;
+}
+
+a.has-text-link-dark:focus,
+a.has-text-link-dark:hover {
+  color: #576dcb !important;
+}
+
+.has-background-link-dark {
+  background-color: #3850b7 !important;
+}
+
+.has-text-info {
+  color: #3e8ed0 !important;
+}
+
+a.has-text-info:focus,
+a.has-text-info:hover {
+  color: #2b74b1 !important;
+}
+
+.has-background-info {
+  background-color: #3e8ed0 !important;
+}
+
+.has-text-info-light {
+  color: #eff5fb !important;
+}
+
+a.has-text-info-light:focus,
+a.has-text-info-light:hover {
+  color: #c6ddf1 !important;
+}
+
+.has-background-info-light {
+  background-color: #eff5fb !important;
+}
+
+.has-text-info-dark {
+  color: #296fa8 !important;
+}
+
+a.has-text-info-dark:focus,
+a.has-text-info-dark:hover {
+  color: #368ace !important;
+}
+
+.has-background-info-dark {
+  background-color: #296fa8 !important;
+}
+
+.has-text-success {
+  color: #48c78e !important;
+}
+
+a.has-text-success:focus,
+a.has-text-success:hover {
+  color: #34a873 !important;
+}
+
+.has-background-success {
+  background-color: #48c78e !important;
+}
+
+.has-text-success-light {
+  color: #effaf5 !important;
+}
+
+a.has-text-success-light:focus,
+a.has-text-success-light:hover {
+  color: #c8eedd !important;
+}
+
+.has-background-success-light {
+  background-color: #effaf5 !important;
+}
+
+.has-text-success-dark {
+  color: #257953 !important;
+}
+
+a.has-text-success-dark:focus,
+a.has-text-success-dark:hover {
+  color: #31a06e !important;
+}
+
+.has-background-success-dark {
+  background-color: #257953 !important;
+}
+
+.has-text-warning {
+  color: #ffe08a !important;
+}
+
+a.has-text-warning:focus,
+a.has-text-warning:hover {
+  color: #ffd257 !important;
+}
+
+.has-background-warning {
+  background-color: #ffe08a !important;
+}
+
+.has-text-warning-light {
+  color: #fffaeb !important;
+}
+
+a.has-text-warning-light:focus,
+a.has-text-warning-light:hover {
+  color: #ffecb8 !important;
+}
+
+.has-background-warning-light {
+  background-color: #fffaeb !important;
+}
+
+.has-text-warning-dark {
+  color: #946c00 !important;
+}
+
+a.has-text-warning-dark:focus,
+a.has-text-warning-dark:hover {
+  color: #c79200 !important;
+}
+
+.has-background-warning-dark {
+  background-color: #946c00 !important;
+}
+
+.has-text-danger {
+  color: #f14668 !important;
+}
+
+a.has-text-danger:focus,
+a.has-text-danger:hover {
+  color: #ee1742 !important;
+}
+
+.has-background-danger {
+  background-color: #f14668 !important;
+}
+
+.has-text-danger-light {
+  color: #feecf0 !important;
+}
+
+a.has-text-danger-light:focus,
+a.has-text-danger-light:hover {
+  color: #fabdc9 !important;
+}
+
+.has-background-danger-light {
+  background-color: #feecf0 !important;
+}
+
+.has-text-danger-dark {
+  color: #cc0f35 !important;
+}
+
+a.has-text-danger-dark:focus,
+a.has-text-danger-dark:hover {
+  color: #ee2049 !important;
+}
+
+.has-background-danger-dark {
+  background-color: #cc0f35 !important;
+}
+
+.has-text-black-bis {
+  color: #121212 !important;
+}
+
+.has-background-black-bis {
+  background-color: #121212 !important;
+}
+
+.has-text-black-ter {
+  color: #242424 !important;
+}
+
+.has-background-black-ter {
+  background-color: #242424 !important;
+}
+
+.has-text-grey-darker {
+  color: #363636 !important;
+}
+
+.has-background-grey-darker {
+  background-color: #363636 !important;
+}
+
+.has-text-grey-dark {
+  color: #4a4a4a !important;
+}
+
+.has-background-grey-dark {
+  background-color: #4a4a4a !important;
+}
+
+.has-text-grey {
+  color: #7a7a7a !important;
+}
+
+.has-background-grey {
+  background-color: #7a7a7a !important;
+}
+
+.has-text-grey-light {
+  color: #b5b5b5 !important;
+}
+
+.has-background-grey-light {
+  background-color: #b5b5b5 !important;
+}
+
+.has-text-grey-lighter {
+  color: #dbdbdb !important;
+}
+
+.has-background-grey-lighter {
+  background-color: #dbdbdb !important;
+}
+
+.has-text-white-ter {
+  color: #f5f5f5 !important;
+}
+
+.has-background-white-ter {
+  background-color: #f5f5f5 !important;
+}
+
+.has-text-white-bis {
+  color: #fafafa !important;
+}
+
+.has-background-white-bis {
+  background-color: #fafafa !important;
+}
+
+.is-flex-direction-row {
+  flex-direction: row !important;
+}
+
+.is-flex-direction-row-reverse {
+  flex-direction: row-reverse !important;
+}
+
+.is-flex-direction-column {
+  flex-direction: column !important;
+}
+
+.is-flex-direction-column-reverse {
+  flex-direction: column-reverse !important;
+}
+
+.is-flex-wrap-nowrap {
+  flex-wrap: nowrap !important;
+}
+
+.is-flex-wrap-wrap {
+  flex-wrap: wrap !important;
+}
+
+.is-flex-wrap-wrap-reverse {
+  flex-wrap: wrap-reverse !important;
+}
+
+.is-justify-content-flex-start {
+  justify-content: flex-start !important;
+}
+
+.is-justify-content-flex-end {
+  justify-content: flex-end !important;
+}
+
+.is-justify-content-center {
+  justify-content: center !important;
+}
+
+.is-justify-content-space-between {
+  justify-content: space-between !important;
+}
+
+.is-justify-content-space-around {
+  justify-content: space-around !important;
+}
+
+.is-justify-content-space-evenly {
+  justify-content: space-evenly !important;
+}
+
+.is-justify-content-start {
+  justify-content: start !important;
+}
+
+.is-justify-content-end {
+  justify-content: end !important;
+}
+
+.is-justify-content-left {
+  justify-content: left !important;
+}
+
+.is-justify-content-right {
+  justify-content: right !important;
+}
+
+.is-align-content-flex-start {
+  align-content: flex-start !important;
+}
+
+.is-align-content-flex-end {
+  align-content: flex-end !important;
+}
+
+.is-align-content-center {
+  align-content: center !important;
+}
+
+.is-align-content-space-between {
+  align-content: space-between !important;
+}
+
+.is-align-content-space-around {
+  align-content: space-around !important;
+}
+
+.is-align-content-space-evenly {
+  align-content: space-evenly !important;
+}
+
+.is-align-content-stretch {
+  align-content: stretch !important;
+}
+
+.is-align-content-start {
+  align-content: start !important;
+}
+
+.is-align-content-end {
+  align-content: end !important;
+}
+
+.is-align-content-baseline {
+  align-content: baseline !important;
+}
+
+.is-align-items-stretch {
+  align-items: stretch !important;
+}
+
+.is-align-items-flex-start {
+  align-items: flex-start !important;
+}
+
+.is-align-items-flex-end {
+  align-items: flex-end !important;
+}
+
+.is-align-items-center {
+  align-items: center !important;
+}
+
+.is-align-items-baseline {
+  align-items: baseline !important;
+}
+
+.is-align-items-start {
+  align-items: start !important;
+}
+
+.is-align-items-end {
+  align-items: end !important;
+}
+
+.is-align-items-self-start {
+  align-items: self-start !important;
+}
+
+.is-align-items-self-end {
+  align-items: self-end !important;
+}
+
+.is-align-self-auto {
+  align-self: auto !important;
+}
+
+.is-align-self-flex-start {
+  align-self: flex-start !important;
+}
+
+.is-align-self-flex-end {
+  align-self: flex-end !important;
+}
+
+.is-align-self-center {
+  align-self: center !important;
+}
+
+.is-align-self-baseline {
+  align-self: baseline !important;
+}
+
+.is-align-self-stretch {
+  align-self: stretch !important;
+}
+
+.is-flex-grow-0 {
+  flex-grow: 0 !important;
+}
+
+.is-flex-grow-1 {
+  flex-grow: 1 !important;
+}
+
+.is-flex-grow-2 {
+  flex-grow: 2 !important;
+}
+
+.is-flex-grow-3 {
+  flex-grow: 3 !important;
+}
+
+.is-flex-grow-4 {
+  flex-grow: 4 !important;
+}
+
+.is-flex-grow-5 {
+  flex-grow: 5 !important;
+}
+
+.is-flex-shrink-0 {
+  flex-shrink: 0 !important;
+}
+
+.is-flex-shrink-1 {
+  flex-shrink: 1 !important;
+}
+
+.is-flex-shrink-2 {
+  flex-shrink: 2 !important;
+}
+
+.is-flex-shrink-3 {
+  flex-shrink: 3 !important;
+}
+
+.is-flex-shrink-4 {
+  flex-shrink: 4 !important;
+}
+
+.is-flex-shrink-5 {
+  flex-shrink: 5 !important;
+}
+
+.is-clearfix::after {
+  clear: both;
+  content: " ";
+  display: table;
+}
+
+.is-pulled-left {
+  float: left !important;
+}
+
+.is-pulled-right {
+  float: right !important;
+}
+
+.is-radiusless {
+  border-radius: 0 !important;
+}
+
+.is-shadowless {
+  box-shadow: none !important;
+}
+
+.is-clickable {
+  cursor: pointer !important;
+  pointer-events: all !important;
+}
+
+.is-clipped {
+  overflow: hidden !important;
+}
+
+.is-relative {
+  position: relative !important;
+}
+
+.is-marginless {
+  margin: 0 !important;
+}
+
+.is-paddingless {
+  padding: 0 !important;
+}
+
+.m-0 {
+  margin: 0 !important;
+}
+
+.mt-0 {
+  margin-top: 0 !important;
+}
+
+.mr-0 {
+  margin-right: 0 !important;
+}
+
+.mb-0 {
+  margin-bottom: 0 !important;
+}
+
+.ml-0 {
+  margin-left: 0 !important;
+}
+
+.mx-0 {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.my-0 {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+}
+
+.m-1 {
+  margin: 0.25rem !important;
+}
+
+.mt-1 {
+  margin-top: 0.25rem !important;
+}
+
+.mr-1 {
+  margin-right: 0.25rem !important;
+}
+
+.mb-1 {
+  margin-bottom: 0.25rem !important;
+}
+
+.ml-1 {
+  margin-left: 0.25rem !important;
+}
+
+.mx-1 {
+  margin-left: 0.25rem !important;
+  margin-right: 0.25rem !important;
+}
+
+.my-1 {
+  margin-top: 0.25rem !important;
+  margin-bottom: 0.25rem !important;
+}
+
+.m-2 {
+  margin: 0.5rem !important;
+}
+
+.mt-2 {
+  margin-top: 0.5rem !important;
+}
+
+.mr-2 {
+  margin-right: 0.5rem !important;
+}
+
+.mb-2 {
+  margin-bottom: 0.5rem !important;
+}
+
+.ml-2 {
+  margin-left: 0.5rem !important;
+}
+
+.mx-2 {
+  margin-left: 0.5rem !important;
+  margin-right: 0.5rem !important;
+}
+
+.my-2 {
+  margin-top: 0.5rem !important;
+  margin-bottom: 0.5rem !important;
+}
+
+.m-3 {
+  margin: 0.75rem !important;
+}
+
+.mt-3 {
+  margin-top: 0.75rem !important;
+}
+
+.mr-3 {
+  margin-right: 0.75rem !important;
+}
+
+.mb-3 {
+  margin-bottom: 0.75rem !important;
+}
+
+.ml-3 {
+  margin-left: 0.75rem !important;
+}
+
+.mx-3 {
+  margin-left: 0.75rem !important;
+  margin-right: 0.75rem !important;
+}
+
+.my-3 {
+  margin-top: 0.75rem !important;
+  margin-bottom: 0.75rem !important;
+}
+
+.m-4 {
+  margin: 1rem !important;
+}
+
+.mt-4 {
+  margin-top: 1rem !important;
+}
+
+.mr-4 {
+  margin-right: 1rem !important;
+}
+
+.mb-4 {
+  margin-bottom: 1rem !important;
+}
+
+.ml-4 {
+  margin-left: 1rem !important;
+}
+
+.mx-4 {
+  margin-left: 1rem !important;
+  margin-right: 1rem !important;
+}
+
+.my-4 {
+  margin-top: 1rem !important;
+  margin-bottom: 1rem !important;
+}
+
+.m-5 {
+  margin: 1.5rem !important;
+}
+
+.mt-5 {
+  margin-top: 1.5rem !important;
+}
+
+.mr-5 {
+  margin-right: 1.5rem !important;
+}
+
+.mb-5 {
+  margin-bottom: 1.5rem !important;
+}
+
+.ml-5 {
+  margin-left: 1.5rem !important;
+}
+
+.mx-5 {
+  margin-left: 1.5rem !important;
+  margin-right: 1.5rem !important;
+}
+
+.my-5 {
+  margin-top: 1.5rem !important;
+  margin-bottom: 1.5rem !important;
+}
+
+.m-6 {
+  margin: 3rem !important;
+}
+
+.mt-6 {
+  margin-top: 3rem !important;
+}
+
+.mr-6 {
+  margin-right: 3rem !important;
+}
+
+.mb-6 {
+  margin-bottom: 3rem !important;
+}
+
+.ml-6 {
+  margin-left: 3rem !important;
+}
+
+.mx-6 {
+  margin-left: 3rem !important;
+  margin-right: 3rem !important;
+}
+
+.my-6 {
+  margin-top: 3rem !important;
+  margin-bottom: 3rem !important;
+}
+
+.m-auto {
+  margin: auto !important;
+}
+
+.mt-auto {
+  margin-top: auto !important;
+}
+
+.mr-auto {
+  margin-right: auto !important;
+}
+
+.mb-auto {
+  margin-bottom: auto !important;
+}
+
+.ml-auto {
+  margin-left: auto !important;
+}
+
+.mx-auto {
+  margin-left: auto !important;
+  margin-right: auto !important;
+}
+
+.my-auto {
+  margin-top: auto !important;
+  margin-bottom: auto !important;
+}
+
+.p-0 {
+  padding: 0 !important;
+}
+
+.pt-0 {
+  padding-top: 0 !important;
+}
+
+.pr-0 {
+  padding-right: 0 !important;
+}
+
+.pb-0 {
+  padding-bottom: 0 !important;
+}
+
+.pl-0 {
+  padding-left: 0 !important;
+}
+
+.px-0 {
+  padding-left: 0 !important;
+  padding-right: 0 !important;
+}
+
+.py-0 {
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+
+.p-1 {
+  padding: 0.25rem !important;
+}
+
+.pt-1 {
+  padding-top: 0.25rem !important;
+}
+
+.pr-1 {
+  padding-right: 0.25rem !important;
+}
+
+.pb-1 {
+  padding-bottom: 0.25rem !important;
+}
+
+.pl-1 {
+  padding-left: 0.25rem !important;
+}
+
+.px-1 {
+  padding-left: 0.25rem !important;
+  padding-right: 0.25rem !important;
+}
+
+.py-1 {
+  padding-top: 0.25rem !important;
+  padding-bottom: 0.25rem !important;
+}
+
+.p-2 {
+  padding: 0.5rem !important;
+}
+
+.pt-2 {
+  padding-top: 0.5rem !important;
+}
+
+.pr-2 {
+  padding-right: 0.5rem !important;
+}
+
+.pb-2 {
+  padding-bottom: 0.5rem !important;
+}
+
+.pl-2 {
+  padding-left: 0.5rem !important;
+}
+
+.px-2 {
+  padding-left: 0.5rem !important;
+  padding-right: 0.5rem !important;
+}
+
+.py-2 {
+  padding-top: 0.5rem !important;
+  padding-bottom: 0.5rem !important;
+}
+
+.p-3 {
+  padding: 0.75rem !important;
+}
+
+.pt-3 {
+  padding-top: 0.75rem !important;
+}
+
+.pr-3 {
+  padding-right: 0.75rem !important;
+}
+
+.pb-3 {
+  padding-bottom: 0.75rem !important;
+}
+
+.pl-3 {
+  padding-left: 0.75rem !important;
+}
+
+.px-3 {
+  padding-left: 0.75rem !important;
+  padding-right: 0.75rem !important;
+}
+
+.py-3 {
+  padding-top: 0.75rem !important;
+  padding-bottom: 0.75rem !important;
+}
+
+.p-4 {
+  padding: 1rem !important;
+}
+
+.pt-4 {
+  padding-top: 1rem !important;
+}
+
+.pr-4 {
+  padding-right: 1rem !important;
+}
+
+.pb-4 {
+  padding-bottom: 1rem !important;
+}
+
+.pl-4 {
+  padding-left: 1rem !important;
+}
+
+.px-4 {
+  padding-left: 1rem !important;
+  padding-right: 1rem !important;
+}
+
+.py-4 {
+  padding-top: 1rem !important;
+  padding-bottom: 1rem !important;
+}
+
+.p-5 {
+  padding: 1.5rem !important;
+}
+
+.pt-5 {
+  padding-top: 1.5rem !important;
+}
+
+.pr-5 {
+  padding-right: 1.5rem !important;
+}
+
+.pb-5 {
+  padding-bottom: 1.5rem !important;
+}
+
+.pl-5 {
+  padding-left: 1.5rem !important;
+}
+
+.px-5 {
+  padding-left: 1.5rem !important;
+  padding-right: 1.5rem !important;
+}
+
+.py-5 {
+  padding-top: 1.5rem !important;
+  padding-bottom: 1.5rem !important;
+}
+
+.p-6 {
+  padding: 3rem !important;
+}
+
+.pt-6 {
+  padding-top: 3rem !important;
+}
+
+.pr-6 {
+  padding-right: 3rem !important;
+}
+
+.pb-6 {
+  padding-bottom: 3rem !important;
+}
+
+.pl-6 {
+  padding-left: 3rem !important;
+}
+
+.px-6 {
+  padding-left: 3rem !important;
+  padding-right: 3rem !important;
+}
+
+.py-6 {
+  padding-top: 3rem !important;
+  padding-bottom: 3rem !important;
+}
+
+.p-auto {
+  padding: auto !important;
+}
+
+.pt-auto {
+  padding-top: auto !important;
+}
+
+.pr-auto {
+  padding-right: auto !important;
+}
+
+.pb-auto {
+  padding-bottom: auto !important;
+}
+
+.pl-auto {
+  padding-left: auto !important;
+}
+
+.px-auto {
+  padding-left: auto !important;
+  padding-right: auto !important;
+}
+
+.py-auto {
+  padding-top: auto !important;
+  padding-bottom: auto !important;
+}
+
+.is-size-1 {
+  font-size: 3rem !important;
+}
+
+.is-size-2 {
+  font-size: 2.5rem !important;
+}
+
+.is-size-3 {
+  font-size: 2rem !important;
+}
+
+.is-size-4 {
+  font-size: 1.5rem !important;
+}
+
+.is-size-5 {
+  font-size: 1.25rem !important;
+}
+
+.is-size-6 {
+  font-size: 1rem !important;
+}
+
+.is-size-7 {
+  font-size: 0.75rem !important;
+}
+
+@media screen and (max-width: 768px) {
+  .is-size-1-mobile {
+    font-size: 3rem !important;
+  }
+
+  .is-size-2-mobile {
+    font-size: 2.5rem !important;
+  }
+
+  .is-size-3-mobile {
+    font-size: 2rem !important;
+  }
+
+  .is-size-4-mobile {
+    font-size: 1.5rem !important;
+  }
+
+  .is-size-5-mobile {
+    font-size: 1.25rem !important;
+  }
+
+  .is-size-6-mobile {
+    font-size: 1rem !important;
+  }
+
+  .is-size-7-mobile {
+    font-size: 0.75rem !important;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .is-size-1-tablet {
+    font-size: 3rem !important;
+  }
+
+  .is-size-2-tablet {
+    font-size: 2.5rem !important;
+  }
+
+  .is-size-3-tablet {
+    font-size: 2rem !important;
+  }
+
+  .is-size-4-tablet {
+    font-size: 1.5rem !important;
+  }
+
+  .is-size-5-tablet {
+    font-size: 1.25rem !important;
+  }
+
+  .is-size-6-tablet {
+    font-size: 1rem !important;
+  }
+
+  .is-size-7-tablet {
+    font-size: 0.75rem !important;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .is-size-1-touch {
+    font-size: 3rem !important;
+  }
+
+  .is-size-2-touch {
+    font-size: 2.5rem !important;
+  }
+
+  .is-size-3-touch {
+    font-size: 2rem !important;
+  }
+
+  .is-size-4-touch {
+    font-size: 1.5rem !important;
+  }
+
+  .is-size-5-touch {
+    font-size: 1.25rem !important;
+  }
+
+  .is-size-6-touch {
+    font-size: 1rem !important;
+  }
+
+  .is-size-7-touch {
+    font-size: 0.75rem !important;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .is-size-1-desktop {
+    font-size: 3rem !important;
+  }
+
+  .is-size-2-desktop {
+    font-size: 2.5rem !important;
+  }
+
+  .is-size-3-desktop {
+    font-size: 2rem !important;
+  }
+
+  .is-size-4-desktop {
+    font-size: 1.5rem !important;
+  }
+
+  .is-size-5-desktop {
+    font-size: 1.25rem !important;
+  }
+
+  .is-size-6-desktop {
+    font-size: 1rem !important;
+  }
+
+  .is-size-7-desktop {
+    font-size: 0.75rem !important;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .is-size-1-widescreen {
+    font-size: 3rem !important;
+  }
+
+  .is-size-2-widescreen {
+    font-size: 2.5rem !important;
+  }
+
+  .is-size-3-widescreen {
+    font-size: 2rem !important;
+  }
+
+  .is-size-4-widescreen {
+    font-size: 1.5rem !important;
+  }
+
+  .is-size-5-widescreen {
+    font-size: 1.25rem !important;
+  }
+
+  .is-size-6-widescreen {
+    font-size: 1rem !important;
+  }
+
+  .is-size-7-widescreen {
+    font-size: 0.75rem !important;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .is-size-1-fullhd {
+    font-size: 3rem !important;
+  }
+
+  .is-size-2-fullhd {
+    font-size: 2.5rem !important;
+  }
+
+  .is-size-3-fullhd {
+    font-size: 2rem !important;
+  }
+
+  .is-size-4-fullhd {
+    font-size: 1.5rem !important;
+  }
+
+  .is-size-5-fullhd {
+    font-size: 1.25rem !important;
+  }
+
+  .is-size-6-fullhd {
+    font-size: 1rem !important;
+  }
+
+  .is-size-7-fullhd {
+    font-size: 0.75rem !important;
+  }
+}
+
+.has-text-centered {
+  text-align: center !important;
+}
+
+.has-text-justified {
+  text-align: justify !important;
+}
+
+.has-text-left {
+  text-align: left !important;
+}
+
+.has-text-right {
+  text-align: right !important;
+}
+
+@media screen and (max-width: 768px) {
+  .has-text-centered-mobile {
+    text-align: center !important;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .has-text-centered-tablet {
+    text-align: center !important;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .has-text-centered-tablet-only {
+    text-align: center !important;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .has-text-centered-touch {
+    text-align: center !important;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .has-text-centered-desktop {
+    text-align: center !important;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .has-text-centered-desktop-only {
+    text-align: center !important;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .has-text-centered-widescreen {
+    text-align: center !important;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .has-text-centered-widescreen-only {
+    text-align: center !important;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .has-text-centered-fullhd {
+    text-align: center !important;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .has-text-justified-mobile {
+    text-align: justify !important;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .has-text-justified-tablet {
+    text-align: justify !important;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .has-text-justified-tablet-only {
+    text-align: justify !important;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .has-text-justified-touch {
+    text-align: justify !important;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .has-text-justified-desktop {
+    text-align: justify !important;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .has-text-justified-desktop-only {
+    text-align: justify !important;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .has-text-justified-widescreen {
+    text-align: justify !important;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .has-text-justified-widescreen-only {
+    text-align: justify !important;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .has-text-justified-fullhd {
+    text-align: justify !important;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .has-text-left-mobile {
+    text-align: left !important;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .has-text-left-tablet {
+    text-align: left !important;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .has-text-left-tablet-only {
+    text-align: left !important;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .has-text-left-touch {
+    text-align: left !important;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .has-text-left-desktop {
+    text-align: left !important;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .has-text-left-desktop-only {
+    text-align: left !important;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .has-text-left-widescreen {
+    text-align: left !important;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .has-text-left-widescreen-only {
+    text-align: left !important;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .has-text-left-fullhd {
+    text-align: left !important;
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .has-text-right-mobile {
+    text-align: right !important;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .has-text-right-tablet {
+    text-align: right !important;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .has-text-right-tablet-only {
+    text-align: right !important;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .has-text-right-touch {
+    text-align: right !important;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .has-text-right-desktop {
+    text-align: right !important;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .has-text-right-desktop-only {
+    text-align: right !important;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .has-text-right-widescreen {
+    text-align: right !important;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .has-text-right-widescreen-only {
+    text-align: right !important;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .has-text-right-fullhd {
+    text-align: right !important;
+  }
+}
+
+.is-capitalized {
+  text-transform: capitalize !important;
+}
+
+.is-lowercase {
+  text-transform: lowercase !important;
+}
+
+.is-uppercase {
+  text-transform: uppercase !important;
+}
+
+.is-italic {
+  font-style: italic !important;
+}
+
+.is-underlined {
+  text-decoration: underline !important;
+}
+
+.has-text-weight-light {
+  font-weight: 300 !important;
+}
+
+.has-text-weight-normal {
+  font-weight: 400 !important;
+}
+
+.has-text-weight-medium {
+  font-weight: 500 !important;
+}
+
+.has-text-weight-semibold {
+  font-weight: 600 !important;
+}
+
+.has-text-weight-bold {
+  font-weight: 700 !important;
+}
+
+.is-family-primary {
+  font-family:
+    BlinkMacSystemFont,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    "Fira Sans",
+    "Droid Sans",
+    "Helvetica Neue",
+    Helvetica,
+    Arial,
+    sans-serif !important;
+}
+
+.is-family-secondary {
+  font-family:
+    BlinkMacSystemFont,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    "Fira Sans",
+    "Droid Sans",
+    "Helvetica Neue",
+    Helvetica,
+    Arial,
+    sans-serif !important;
+}
+
+.is-family-sans-serif {
+  font-family:
+    BlinkMacSystemFont,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    "Fira Sans",
+    "Droid Sans",
+    "Helvetica Neue",
+    Helvetica,
+    Arial,
+    sans-serif !important;
+}
+
+.is-family-monospace {
+  font-family: monospace !important;
+}
+
+.is-family-code {
+  font-family: monospace !important;
+}
+
+.is-block {
+  display: block !important;
+}
+
+@media screen and (max-width: 768px) {
+  .is-block-mobile {
+    display: block !important;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .is-block-tablet {
+    display: block !important;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-block-tablet-only {
+    display: block !important;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .is-block-touch {
+    display: block !important;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .is-block-desktop {
+    display: block !important;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-block-desktop-only {
+    display: block !important;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .is-block-widescreen {
+    display: block !important;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-block-widescreen-only {
+    display: block !important;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .is-block-fullhd {
+    display: block !important;
+  }
+}
+
+.is-flex {
+  display: flex !important;
+}
+
+@media screen and (max-width: 768px) {
+  .is-flex-mobile {
+    display: flex !important;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .is-flex-tablet {
+    display: flex !important;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-flex-tablet-only {
+    display: flex !important;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .is-flex-touch {
+    display: flex !important;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .is-flex-desktop {
+    display: flex !important;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-flex-desktop-only {
+    display: flex !important;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .is-flex-widescreen {
+    display: flex !important;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-flex-widescreen-only {
+    display: flex !important;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .is-flex-fullhd {
+    display: flex !important;
+  }
+}
+
+.is-inline {
+  display: inline !important;
+}
+
+@media screen and (max-width: 768px) {
+  .is-inline-mobile {
+    display: inline !important;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .is-inline-tablet {
+    display: inline !important;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-inline-tablet-only {
+    display: inline !important;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .is-inline-touch {
+    display: inline !important;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .is-inline-desktop {
+    display: inline !important;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-inline-desktop-only {
+    display: inline !important;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .is-inline-widescreen {
+    display: inline !important;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-inline-widescreen-only {
+    display: inline !important;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .is-inline-fullhd {
+    display: inline !important;
+  }
+}
+
+.is-inline-block {
+  display: inline-block !important;
+}
+
+@media screen and (max-width: 768px) {
+  .is-inline-block-mobile {
+    display: inline-block !important;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .is-inline-block-tablet {
+    display: inline-block !important;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-inline-block-tablet-only {
+    display: inline-block !important;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .is-inline-block-touch {
+    display: inline-block !important;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .is-inline-block-desktop {
+    display: inline-block !important;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-inline-block-desktop-only {
+    display: inline-block !important;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .is-inline-block-widescreen {
+    display: inline-block !important;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-inline-block-widescreen-only {
+    display: inline-block !important;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .is-inline-block-fullhd {
+    display: inline-block !important;
+  }
+}
+
+.is-inline-flex {
+  display: inline-flex !important;
+}
+
+@media screen and (max-width: 768px) {
+  .is-inline-flex-mobile {
+    display: inline-flex !important;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .is-inline-flex-tablet {
+    display: inline-flex !important;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-inline-flex-tablet-only {
+    display: inline-flex !important;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .is-inline-flex-touch {
+    display: inline-flex !important;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .is-inline-flex-desktop {
+    display: inline-flex !important;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-inline-flex-desktop-only {
+    display: inline-flex !important;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .is-inline-flex-widescreen {
+    display: inline-flex !important;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-inline-flex-widescreen-only {
+    display: inline-flex !important;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .is-inline-flex-fullhd {
+    display: inline-flex !important;
+  }
+}
+
+.is-hidden {
+  display: none !important;
+}
+
+.is-sr-only {
+  border: none !important;
+  clip: rect(0, 0, 0, 0) !important;
+  height: 0.01em !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  white-space: nowrap !important;
+  width: 0.01em !important;
+}
+
+@media screen and (max-width: 768px) {
+  .is-hidden-mobile {
+    display: none !important;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .is-hidden-tablet {
+    display: none !important;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-hidden-tablet-only {
+    display: none !important;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .is-hidden-touch {
+    display: none !important;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .is-hidden-desktop {
+    display: none !important;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-hidden-desktop-only {
+    display: none !important;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .is-hidden-widescreen {
+    display: none !important;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-hidden-widescreen-only {
+    display: none !important;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .is-hidden-fullhd {
+    display: none !important;
+  }
+}
+
+.is-invisible {
+  visibility: hidden !important;
+}
+
+@media screen and (max-width: 768px) {
+  .is-invisible-mobile {
+    visibility: hidden !important;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .is-invisible-tablet {
+    visibility: hidden !important;
+  }
+}
+
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .is-invisible-tablet-only {
+    visibility: hidden !important;
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .is-invisible-touch {
+    visibility: hidden !important;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .is-invisible-desktop {
+    visibility: hidden !important;
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .is-invisible-desktop-only {
+    visibility: hidden !important;
+  }
+}
+
+@media screen and (min-width: 1216px) {
+  .is-invisible-widescreen {
+    visibility: hidden !important;
+  }
+}
+
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .is-invisible-widescreen-only {
+    visibility: hidden !important;
+  }
+}
+
+@media screen and (min-width: 1408px) {
+  .is-invisible-fullhd {
+    visibility: hidden !important;
+  }
+}
+
+.hero {
+  align-items: stretch;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.hero .navbar {
+  background: 0 0;
+}
+
+.hero .tabs ul {
+  border-bottom: none;
+}
+
+.hero.is-white {
+  background-color: #fff;
+  color: #0a0a0a;
+}
+
+.hero.is-white
+  a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+.hero.is-white strong {
+  color: inherit;
+}
+
+.hero.is-white .title {
+  color: #0a0a0a;
+}
+
+.hero.is-white .subtitle {
+  color: rgba(10, 10, 10, 0.9);
+}
+
+.hero.is-white .subtitle a:not(.button),
+.hero.is-white .subtitle strong {
+  color: #0a0a0a;
+}
+
+@media screen and (max-width: 1023px) {
+  .hero.is-white .navbar-menu {
+    background-color: #fff;
+  }
+}
+
+.hero.is-white .navbar-item,
+.hero.is-white .navbar-link {
+  color: rgba(10, 10, 10, 0.7);
+}
+
+.hero.is-white .navbar-link.is-active,
+.hero.is-white .navbar-link:hover,
+.hero.is-white a.navbar-item.is-active,
+.hero.is-white a.navbar-item:hover {
+  background-color: #f2f2f2;
+  color: #0a0a0a;
+}
+
+.hero.is-white .tabs a {
+  color: #0a0a0a;
+  opacity: 0.9;
+}
+
+.hero.is-white .tabs a:hover {
+  opacity: 1;
+}
+
+.hero.is-white .tabs li.is-active a {
+  color: #fff !important;
+  opacity: 1;
+}
+
+.hero.is-white .tabs.is-boxed a,
+.hero.is-white .tabs.is-toggle a {
+  color: #0a0a0a;
+}
+
+.hero.is-white .tabs.is-boxed a:hover,
+.hero.is-white .tabs.is-toggle a:hover {
+  background-color: rgba(10, 10, 10, 0.1);
+}
+
+.hero.is-white .tabs.is-boxed li.is-active a,
+.hero.is-white .tabs.is-boxed li.is-active a:hover,
+.hero.is-white .tabs.is-toggle li.is-active a,
+.hero.is-white .tabs.is-toggle li.is-active a:hover {
+  background-color: #0a0a0a;
+  border-color: #0a0a0a;
+  color: #fff;
+}
+
+.hero.is-white.is-bold {
+  background-image: linear-gradient(141deg, #e6e6e6 0, #fff 71%, #fff 100%);
+}
+
+@media screen and (max-width: 768px) {
+  .hero.is-white.is-bold .navbar-menu {
+    background-image: linear-gradient(141deg, #e6e6e6 0, #fff 71%, #fff 100%);
+  }
+}
+
+.hero.is-black {
+  background-color: #0a0a0a;
+  color: #fff;
+}
+
+.hero.is-black
+  a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+.hero.is-black strong {
+  color: inherit;
+}
+
+.hero.is-black .title {
+  color: #fff;
+}
+
+.hero.is-black .subtitle {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.hero.is-black .subtitle a:not(.button),
+.hero.is-black .subtitle strong {
+  color: #fff;
+}
+
+@media screen and (max-width: 1023px) {
+  .hero.is-black .navbar-menu {
+    background-color: #0a0a0a;
+  }
+}
+
+.hero.is-black .navbar-item,
+.hero.is-black .navbar-link {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.hero.is-black .navbar-link.is-active,
+.hero.is-black .navbar-link:hover,
+.hero.is-black a.navbar-item.is-active,
+.hero.is-black a.navbar-item:hover {
+  background-color: #000;
+  color: #fff;
+}
+
+.hero.is-black .tabs a {
+  color: #fff;
+  opacity: 0.9;
+}
+
+.hero.is-black .tabs a:hover {
+  opacity: 1;
+}
+
+.hero.is-black .tabs li.is-active a {
+  color: #0a0a0a !important;
+  opacity: 1;
+}
+
+.hero.is-black .tabs.is-boxed a,
+.hero.is-black .tabs.is-toggle a {
+  color: #fff;
+}
+
+.hero.is-black .tabs.is-boxed a:hover,
+.hero.is-black .tabs.is-toggle a:hover {
+  background-color: rgba(10, 10, 10, 0.1);
+}
+
+.hero.is-black .tabs.is-boxed li.is-active a,
+.hero.is-black .tabs.is-boxed li.is-active a:hover,
+.hero.is-black .tabs.is-toggle li.is-active a,
+.hero.is-black .tabs.is-toggle li.is-active a:hover {
+  background-color: #fff;
+  border-color: #fff;
+  color: #0a0a0a;
+}
+
+.hero.is-black.is-bold {
+  background-image: linear-gradient(141deg, #000 0, #0a0a0a 71%, #181616 100%);
+}
+
+@media screen and (max-width: 768px) {
+  .hero.is-black.is-bold .navbar-menu {
+    background-image: linear-gradient(
+      141deg,
+      #000 0,
+      #0a0a0a 71%,
+      #181616 100%
+    );
+  }
+}
+
+.hero.is-light {
+  background-color: #f5f5f5;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.hero.is-light
+  a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+.hero.is-light strong {
+  color: inherit;
+}
+
+.hero.is-light .title {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.hero.is-light .subtitle {
+  color: rgba(0, 0, 0, 0.9);
+}
+
+.hero.is-light .subtitle a:not(.button),
+.hero.is-light .subtitle strong {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+@media screen and (max-width: 1023px) {
+  .hero.is-light .navbar-menu {
+    background-color: #f5f5f5;
+  }
+}
+
+.hero.is-light .navbar-item,
+.hero.is-light .navbar-link {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.hero.is-light .navbar-link.is-active,
+.hero.is-light .navbar-link:hover,
+.hero.is-light a.navbar-item.is-active,
+.hero.is-light a.navbar-item:hover {
+  background-color: #e8e8e8;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.hero.is-light .tabs a {
+  color: rgba(0, 0, 0, 0.7);
+  opacity: 0.9;
+}
+
+.hero.is-light .tabs a:hover {
+  opacity: 1;
+}
+
+.hero.is-light .tabs li.is-active a {
+  color: #f5f5f5 !important;
+  opacity: 1;
+}
+
+.hero.is-light .tabs.is-boxed a,
+.hero.is-light .tabs.is-toggle a {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.hero.is-light .tabs.is-boxed a:hover,
+.hero.is-light .tabs.is-toggle a:hover {
+  background-color: rgba(10, 10, 10, 0.1);
+}
+
+.hero.is-light .tabs.is-boxed li.is-active a,
+.hero.is-light .tabs.is-boxed li.is-active a:hover,
+.hero.is-light .tabs.is-toggle li.is-active a,
+.hero.is-light .tabs.is-toggle li.is-active a:hover {
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(0, 0, 0, 0.7);
+  color: #f5f5f5;
+}
+
+.hero.is-light.is-bold {
+  background-image: linear-gradient(141deg, #dfd8d9 0, #f5f5f5 71%, #fff 100%);
+}
+
+@media screen and (max-width: 768px) {
+  .hero.is-light.is-bold .navbar-menu {
+    background-image: linear-gradient(
+      141deg,
+      #dfd8d9 0,
+      #f5f5f5 71%,
+      #fff 100%
+    );
+  }
+}
+
+.hero.is-dark {
+  background-color: #363636;
+  color: #fff;
+}
+
+.hero.is-dark
+  a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+.hero.is-dark strong {
+  color: inherit;
+}
+
+.hero.is-dark .title {
+  color: #fff;
+}
+
+.hero.is-dark .subtitle {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.hero.is-dark .subtitle a:not(.button),
+.hero.is-dark .subtitle strong {
+  color: #fff;
+}
+
+@media screen and (max-width: 1023px) {
+  .hero.is-dark .navbar-menu {
+    background-color: #363636;
+  }
+}
+
+.hero.is-dark .navbar-item,
+.hero.is-dark .navbar-link {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.hero.is-dark .navbar-link.is-active,
+.hero.is-dark .navbar-link:hover,
+.hero.is-dark a.navbar-item.is-active,
+.hero.is-dark a.navbar-item:hover {
+  background-color: #292929;
+  color: #fff;
+}
+
+.hero.is-dark .tabs a {
+  color: #fff;
+  opacity: 0.9;
+}
+
+.hero.is-dark .tabs a:hover {
+  opacity: 1;
+}
+
+.hero.is-dark .tabs li.is-active a {
+  color: #363636 !important;
+  opacity: 1;
+}
+
+.hero.is-dark .tabs.is-boxed a,
+.hero.is-dark .tabs.is-toggle a {
+  color: #fff;
+}
+
+.hero.is-dark .tabs.is-boxed a:hover,
+.hero.is-dark .tabs.is-toggle a:hover {
+  background-color: rgba(10, 10, 10, 0.1);
+}
+
+.hero.is-dark .tabs.is-boxed li.is-active a,
+.hero.is-dark .tabs.is-boxed li.is-active a:hover,
+.hero.is-dark .tabs.is-toggle li.is-active a,
+.hero.is-dark .tabs.is-toggle li.is-active a:hover {
+  background-color: #fff;
+  border-color: #fff;
+  color: #363636;
+}
+
+.hero.is-dark.is-bold {
+  background-image: linear-gradient(
+    141deg,
+    #1f191a 0,
+    #363636 71%,
+    #46403f 100%
+  );
+}
+
+@media screen and (max-width: 768px) {
+  .hero.is-dark.is-bold .navbar-menu {
+    background-image: linear-gradient(
+      141deg,
+      #1f191a 0,
+      #363636 71%,
+      #46403f 100%
+    );
+  }
+}
+
+.hero.is-primary {
+  background-color: #00d1b2;
+  color: #fff;
+}
+
+.hero.is-primary
+  a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+.hero.is-primary strong {
+  color: inherit;
+}
+
+.hero.is-primary .title {
+  color: #fff;
+}
+
+.hero.is-primary .subtitle {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.hero.is-primary .subtitle a:not(.button),
+.hero.is-primary .subtitle strong {
+  color: #fff;
+}
+
+@media screen and (max-width: 1023px) {
+  .hero.is-primary .navbar-menu {
+    background-color: #00d1b2;
+  }
+}
+
+.hero.is-primary .navbar-item,
+.hero.is-primary .navbar-link {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.hero.is-primary .navbar-link.is-active,
+.hero.is-primary .navbar-link:hover,
+.hero.is-primary a.navbar-item.is-active,
+.hero.is-primary a.navbar-item:hover {
+  background-color: #00b89c;
+  color: #fff;
+}
+
+.hero.is-primary .tabs a {
+  color: #fff;
+  opacity: 0.9;
+}
+
+.hero.is-primary .tabs a:hover {
+  opacity: 1;
+}
+
+.hero.is-primary .tabs li.is-active a {
+  color: #00d1b2 !important;
+  opacity: 1;
+}
+
+.hero.is-primary .tabs.is-boxed a,
+.hero.is-primary .tabs.is-toggle a {
+  color: #fff;
+}
+
+.hero.is-primary .tabs.is-boxed a:hover,
+.hero.is-primary .tabs.is-toggle a:hover {
+  background-color: rgba(10, 10, 10, 0.1);
+}
+
+.hero.is-primary .tabs.is-boxed li.is-active a,
+.hero.is-primary .tabs.is-boxed li.is-active a:hover,
+.hero.is-primary .tabs.is-toggle li.is-active a,
+.hero.is-primary .tabs.is-toggle li.is-active a:hover {
+  background-color: #fff;
+  border-color: #fff;
+  color: #00d1b2;
+}
+
+.hero.is-primary.is-bold {
+  background-image: linear-gradient(
+    141deg,
+    #009e6c 0,
+    #00d1b2 71%,
+    #00e7eb 100%
+  );
+}
+
+@media screen and (max-width: 768px) {
+  .hero.is-primary.is-bold .navbar-menu {
+    background-image: linear-gradient(
+      141deg,
+      #009e6c 0,
+      #00d1b2 71%,
+      #00e7eb 100%
+    );
+  }
+}
+
+.hero.is-link {
+  background-color: #485fc7;
+  color: #fff;
+}
+
+.hero.is-link
+  a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+.hero.is-link strong {
+  color: inherit;
+}
+
+.hero.is-link .title {
+  color: #fff;
+}
+
+.hero.is-link .subtitle {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.hero.is-link .subtitle a:not(.button),
+.hero.is-link .subtitle strong {
+  color: #fff;
+}
+
+@media screen and (max-width: 1023px) {
+  .hero.is-link .navbar-menu {
+    background-color: #485fc7;
+  }
+}
+
+.hero.is-link .navbar-item,
+.hero.is-link .navbar-link {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.hero.is-link .navbar-link.is-active,
+.hero.is-link .navbar-link:hover,
+.hero.is-link a.navbar-item.is-active,
+.hero.is-link a.navbar-item:hover {
+  background-color: #3a51bb;
+  color: #fff;
+}
+
+.hero.is-link .tabs a {
+  color: #fff;
+  opacity: 0.9;
+}
+
+.hero.is-link .tabs a:hover {
+  opacity: 1;
+}
+
+.hero.is-link .tabs li.is-active a {
+  color: #485fc7 !important;
+  opacity: 1;
+}
+
+.hero.is-link .tabs.is-boxed a,
+.hero.is-link .tabs.is-toggle a {
+  color: #fff;
+}
+
+.hero.is-link .tabs.is-boxed a:hover,
+.hero.is-link .tabs.is-toggle a:hover {
+  background-color: rgba(10, 10, 10, 0.1);
+}
+
+.hero.is-link .tabs.is-boxed li.is-active a,
+.hero.is-link .tabs.is-boxed li.is-active a:hover,
+.hero.is-link .tabs.is-toggle li.is-active a,
+.hero.is-link .tabs.is-toggle li.is-active a:hover {
+  background-color: #fff;
+  border-color: #fff;
+  color: #485fc7;
+}
+
+.hero.is-link.is-bold {
+  background-image: linear-gradient(
+    141deg,
+    #2959b3 0,
+    #485fc7 71%,
+    #5658d2 100%
+  );
+}
+
+@media screen and (max-width: 768px) {
+  .hero.is-link.is-bold .navbar-menu {
+    background-image: linear-gradient(
+      141deg,
+      #2959b3 0,
+      #485fc7 71%,
+      #5658d2 100%
+    );
+  }
+}
+
+.hero.is-info {
+  background-color: #3e8ed0;
+  color: #fff;
+}
+
+.hero.is-info
+  a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+.hero.is-info strong {
+  color: inherit;
+}
+
+.hero.is-info .title {
+  color: #fff;
+}
+
+.hero.is-info .subtitle {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.hero.is-info .subtitle a:not(.button),
+.hero.is-info .subtitle strong {
+  color: #fff;
+}
+
+@media screen and (max-width: 1023px) {
+  .hero.is-info .navbar-menu {
+    background-color: #3e8ed0;
+  }
+}
+
+.hero.is-info .navbar-item,
+.hero.is-info .navbar-link {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.hero.is-info .navbar-link.is-active,
+.hero.is-info .navbar-link:hover,
+.hero.is-info a.navbar-item.is-active,
+.hero.is-info a.navbar-item:hover {
+  background-color: #3082c5;
+  color: #fff;
+}
+
+.hero.is-info .tabs a {
+  color: #fff;
+  opacity: 0.9;
+}
+
+.hero.is-info .tabs a:hover {
+  opacity: 1;
+}
+
+.hero.is-info .tabs li.is-active a {
+  color: #3e8ed0 !important;
+  opacity: 1;
+}
+
+.hero.is-info .tabs.is-boxed a,
+.hero.is-info .tabs.is-toggle a {
+  color: #fff;
+}
+
+.hero.is-info .tabs.is-boxed a:hover,
+.hero.is-info .tabs.is-toggle a:hover {
+  background-color: rgba(10, 10, 10, 0.1);
+}
+
+.hero.is-info .tabs.is-boxed li.is-active a,
+.hero.is-info .tabs.is-boxed li.is-active a:hover,
+.hero.is-info .tabs.is-toggle li.is-active a,
+.hero.is-info .tabs.is-toggle li.is-active a:hover {
+  background-color: #fff;
+  border-color: #fff;
+  color: #3e8ed0;
+}
+
+.hero.is-info.is-bold {
+  background-image: linear-gradient(
+    141deg,
+    #208fbc 0,
+    #3e8ed0 71%,
+    #4d83db 100%
+  );
+}
+
+@media screen and (max-width: 768px) {
+  .hero.is-info.is-bold .navbar-menu {
+    background-image: linear-gradient(
+      141deg,
+      #208fbc 0,
+      #3e8ed0 71%,
+      #4d83db 100%
+    );
+  }
+}
+
+.hero.is-success {
+  background-color: #48c78e;
+  color: #fff;
+}
+
+.hero.is-success
+  a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+.hero.is-success strong {
+  color: inherit;
+}
+
+.hero.is-success .title {
+  color: #fff;
+}
+
+.hero.is-success .subtitle {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.hero.is-success .subtitle a:not(.button),
+.hero.is-success .subtitle strong {
+  color: #fff;
+}
+
+@media screen and (max-width: 1023px) {
+  .hero.is-success .navbar-menu {
+    background-color: #48c78e;
+  }
+}
+
+.hero.is-success .navbar-item,
+.hero.is-success .navbar-link {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.hero.is-success .navbar-link.is-active,
+.hero.is-success .navbar-link:hover,
+.hero.is-success a.navbar-item.is-active,
+.hero.is-success a.navbar-item:hover {
+  background-color: #3abb81;
+  color: #fff;
+}
+
+.hero.is-success .tabs a {
+  color: #fff;
+  opacity: 0.9;
+}
+
+.hero.is-success .tabs a:hover {
+  opacity: 1;
+}
+
+.hero.is-success .tabs li.is-active a {
+  color: #48c78e !important;
+  opacity: 1;
+}
+
+.hero.is-success .tabs.is-boxed a,
+.hero.is-success .tabs.is-toggle a {
+  color: #fff;
+}
+
+.hero.is-success .tabs.is-boxed a:hover,
+.hero.is-success .tabs.is-toggle a:hover {
+  background-color: rgba(10, 10, 10, 0.1);
+}
+
+.hero.is-success .tabs.is-boxed li.is-active a,
+.hero.is-success .tabs.is-boxed li.is-active a:hover,
+.hero.is-success .tabs.is-toggle li.is-active a,
+.hero.is-success .tabs.is-toggle li.is-active a:hover {
+  background-color: #fff;
+  border-color: #fff;
+  color: #48c78e;
+}
+
+.hero.is-success.is-bold {
+  background-image: linear-gradient(
+    141deg,
+    #29b35e 0,
+    #48c78e 71%,
+    #56d2af 100%
+  );
+}
+
+@media screen and (max-width: 768px) {
+  .hero.is-success.is-bold .navbar-menu {
+    background-image: linear-gradient(
+      141deg,
+      #29b35e 0,
+      #48c78e 71%,
+      #56d2af 100%
+    );
+  }
+}
+
+.hero.is-warning {
+  background-color: #ffe08a;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.hero.is-warning
+  a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+.hero.is-warning strong {
+  color: inherit;
+}
+
+.hero.is-warning .title {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.hero.is-warning .subtitle {
+  color: rgba(0, 0, 0, 0.9);
+}
+
+.hero.is-warning .subtitle a:not(.button),
+.hero.is-warning .subtitle strong {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+@media screen and (max-width: 1023px) {
+  .hero.is-warning .navbar-menu {
+    background-color: #ffe08a;
+  }
+}
+
+.hero.is-warning .navbar-item,
+.hero.is-warning .navbar-link {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.hero.is-warning .navbar-link.is-active,
+.hero.is-warning .navbar-link:hover,
+.hero.is-warning a.navbar-item.is-active,
+.hero.is-warning a.navbar-item:hover {
+  background-color: #ffd970;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.hero.is-warning .tabs a {
+  color: rgba(0, 0, 0, 0.7);
+  opacity: 0.9;
+}
+
+.hero.is-warning .tabs a:hover {
+  opacity: 1;
+}
+
+.hero.is-warning .tabs li.is-active a {
+  color: #ffe08a !important;
+  opacity: 1;
+}
+
+.hero.is-warning .tabs.is-boxed a,
+.hero.is-warning .tabs.is-toggle a {
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.hero.is-warning .tabs.is-boxed a:hover,
+.hero.is-warning .tabs.is-toggle a:hover {
+  background-color: rgba(10, 10, 10, 0.1);
+}
+
+.hero.is-warning .tabs.is-boxed li.is-active a,
+.hero.is-warning .tabs.is-boxed li.is-active a:hover,
+.hero.is-warning .tabs.is-toggle li.is-active a,
+.hero.is-warning .tabs.is-toggle li.is-active a:hover {
+  background-color: rgba(0, 0, 0, 0.7);
+  border-color: rgba(0, 0, 0, 0.7);
+  color: #ffe08a;
+}
+
+.hero.is-warning.is-bold {
+  background-image: linear-gradient(
+    141deg,
+    #ffb657 0,
+    #ffe08a 71%,
+    #fff6a3 100%
+  );
+}
+
+@media screen and (max-width: 768px) {
+  .hero.is-warning.is-bold .navbar-menu {
+    background-image: linear-gradient(
+      141deg,
+      #ffb657 0,
+      #ffe08a 71%,
+      #fff6a3 100%
+    );
+  }
+}
+
+.hero.is-danger {
+  background-color: #f14668;
+  color: #fff;
+}
+
+.hero.is-danger
+  a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
+.hero.is-danger strong {
+  color: inherit;
+}
+
+.hero.is-danger .title {
+  color: #fff;
+}
+
+.hero.is-danger .subtitle {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.hero.is-danger .subtitle a:not(.button),
+.hero.is-danger .subtitle strong {
+  color: #fff;
+}
+
+@media screen and (max-width: 1023px) {
+  .hero.is-danger .navbar-menu {
+    background-color: #f14668;
+  }
+}
+
+.hero.is-danger .navbar-item,
+.hero.is-danger .navbar-link {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.hero.is-danger .navbar-link.is-active,
+.hero.is-danger .navbar-link:hover,
+.hero.is-danger a.navbar-item.is-active,
+.hero.is-danger a.navbar-item:hover {
+  background-color: #ef2e55;
+  color: #fff;
+}
+
+.hero.is-danger .tabs a {
+  color: #fff;
+  opacity: 0.9;
+}
+
+.hero.is-danger .tabs a:hover {
+  opacity: 1;
+}
+
+.hero.is-danger .tabs li.is-active a {
+  color: #f14668 !important;
+  opacity: 1;
+}
+
+.hero.is-danger .tabs.is-boxed a,
+.hero.is-danger .tabs.is-toggle a {
+  color: #fff;
+}
+
+.hero.is-danger .tabs.is-boxed a:hover,
+.hero.is-danger .tabs.is-toggle a:hover {
+  background-color: rgba(10, 10, 10, 0.1);
+}
+
+.hero.is-danger .tabs.is-boxed li.is-active a,
+.hero.is-danger .tabs.is-boxed li.is-active a:hover,
+.hero.is-danger .tabs.is-toggle li.is-active a,
+.hero.is-danger .tabs.is-toggle li.is-active a:hover {
+  background-color: #fff;
+  border-color: #fff;
+  color: #f14668;
+}
+
+.hero.is-danger.is-bold {
+  background-image: linear-gradient(
+    141deg,
+    #fa0a62 0,
+    #f14668 71%,
+    #f7595f 100%
+  );
+}
+
+@media screen and (max-width: 768px) {
+  .hero.is-danger.is-bold .navbar-menu {
+    background-image: linear-gradient(
+      141deg,
+      #fa0a62 0,
+      #f14668 71%,
+      #f7595f 100%
+    );
+  }
+}
+
+.hero.is-small .hero-body {
+  padding: 1.5rem;
+}
+
+@media screen and (min-width: 769px), print {
+  .hero.is-medium .hero-body {
+    padding: 9rem 4.5rem;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .hero.is-large .hero-body {
+    padding: 18rem 6rem;
+  }
+}
+
+.hero.is-fullheight .hero-body,
+.hero.is-fullheight-with-navbar .hero-body,
+.hero.is-halfheight .hero-body {
+  align-items: center;
+  display: flex;
+}
+
+.hero.is-fullheight .hero-body > .container,
+.hero.is-fullheight-with-navbar .hero-body > .container,
+.hero.is-halfheight .hero-body > .container {
+  flex-grow: 1;
+  flex-shrink: 1;
+}
+
+.hero.is-halfheight {
+  min-height: 50vh;
+}
+
+.hero.is-fullheight {
+  min-height: 100vh;
+}
+
+.hero-video {
+  overflow: hidden;
+}
+
+.hero-video video {
+  left: 50%;
+  min-height: 100%;
+  min-width: 100%;
+  position: absolute;
+  top: 50%;
+  transform: translate3d(-50%, -50%, 0);
+}
+
+.hero-video.is-transparent {
+  opacity: 0.3;
+}
+
+@media screen and (max-width: 768px) {
+  .hero-video {
+    display: none;
+  }
+}
+
+.hero-buttons {
+  margin-top: 1.5rem;
+}
+
+@media screen and (max-width: 768px) {
+  .hero-buttons .button {
+    display: flex;
+  }
+
+  .hero-buttons .button:not(:last-child) {
+    margin-bottom: 0.75rem;
+  }
+}
+
+@media screen and (min-width: 769px), print {
+  .hero-buttons {
+    display: flex;
+    justify-content: center;
+  }
+
+  .hero-buttons .button:not(:last-child) {
+    margin-right: 1.5rem;
+  }
+}
+
+.hero-foot,
+.hero-head {
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+
+.hero-body {
+  flex-grow: 1;
+  flex-shrink: 0;
+  padding: 3rem 1.5rem;
+}
+
+@media screen and (min-width: 769px), print {
+  .hero-body {
+    padding: 3rem 3rem;
+  }
+}
+
+.section {
+  padding: 3rem 1.5rem;
+}
+
+@media screen and (min-width: 1024px) {
+  .section {
+    padding: 3rem 3rem;
+  }
+
+  .section.is-medium {
+    padding: 9rem 4.5rem;
+  }
+
+  .section.is-large {
+    padding: 18rem 6rem;
+  }
+}
+
+.footer {
+  background-color: #fafafa;
+  padding: 3rem 1.5rem 6rem;
+}

--- a/oauth2-proxy-templates/robots.txt
+++ b/oauth2-proxy-templates/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/oauth2-proxy-templates/sign_in.html
+++ b/oauth2-proxy-templates/sign_in.html
@@ -1,0 +1,151 @@
+{{define "sign_in.html"}}
+<!doctype html>
+<html lang="en" charset="utf-8">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
+    <title>Sign In</title>
+    <link rel="stylesheet" href="./msf.css" />
+
+    <style>
+      body {
+        height: 100vh;
+      }
+      .sign-in-box {
+        max-width: 400px;
+        margin: 1.25rem auto;
+      }
+      .logo-box {
+        margin: 1.5rem 3rem;
+      }
+      .alert {
+        padding: 5px;
+        background-color: #f44336; /* Red */
+        color: white;
+        margin-bottom: 5px;
+        border-radius: 5px;
+      }
+      /* The close button */
+      .closebtn {
+        margin-left: 10px;
+        color: white;
+        font-weight: bold;
+        float: right;
+        font-size: 22px;
+        line-height: 20px;
+        cursor: pointer;
+        transition: 0.3s;
+      }
+      /* When moving the mouse over the close button */
+      .closebtn:hover {
+        color: black;
+      }
+      footer a {
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body class="has-background-light">
+    <section class="section has-background-light">
+      <div class="box block sign-in-box has-text-centered">
+        {{ if .LogoData }}
+        <div class="block logo-box">{{.LogoData}}</div>
+        {{ end }}
+
+        <form method="GET" action="{{.ProxyPrefix}}/start">
+          <input type="hidden" name="rd" value="{{.Redirect}}" />
+          {{ if .SignInMessage }}
+          <p class="block">{{.SignInMessage}}</p>
+          {{ end}}
+          <button type="submit" class="button block is-primary">
+            Sign in with {{.ProviderName}}
+          </button>
+        </form>
+
+        {{ if .CustomLogin }}
+        <hr />
+
+        <form method="POST" action="{{.ProxyPrefix}}/sign_in" class="block">
+          <input type="hidden" name="rd" value="{{.Redirect}}" />
+
+          <div class="field">
+            <label class="label" for="username">Username</label>
+            <div class="control">
+              <input
+                class="input"
+                type="text"
+                placeholder="e.g. userx@example.com"
+                name="username"
+                id="username"
+              />
+            </div>
+          </div>
+
+          <div class="field">
+            <label class="label" for="password">Password</label>
+            <div class="control">
+              <input
+                class="input"
+                type="password"
+                placeholder="********"
+                name="password"
+                id="password"
+              />
+            </div>
+          </div>
+          <button class="button is-primary">Sign in</button>
+        </form>
+        {{ end }} {{ if eq .StatusCode 400 401 }}
+        <div class="alert">
+          <span
+            class="closebtn"
+            onclick="this.parentElement.style.display='none';"
+            >&times;</span
+          >
+          {{ if eq .StatusCode 400 }} {{.StatusCode}}: Username cannot be empty
+          {{ else }} {{.StatusCode}}: Invalid Username or Password {{ end }}
+        </div>
+        {{ end }}
+      </div>
+    </section>
+
+    <script>
+      if (window.location.hash) {
+        (function () {
+          var inputs = document.getElementsByName("rd");
+          for (var i = 0; i < inputs.length; i++) {
+            // Add hash, but make sure it is only added once
+            var idx = inputs[i].value.indexOf("#");
+            if (idx >= 0) {
+              // Remove existing hash from URL
+              inputs[i].value = inputs[i].value.substr(0, idx);
+            }
+            inputs[i].value += window.location.hash;
+          }
+        })();
+      }
+    </script>
+
+    <footer class="footer has-text-grey has-background-light is-size-7">
+      <div class="content has-text-centered">
+        {{ if eq .Footer "-" }} {{ else if eq .Footer ""}}
+        <p>
+          Secured with
+          <a
+            href="https://github.com/oauth2-proxy/oauth2-proxy#oauth2_proxy"
+            class="has-text-grey"
+            >OAuth2 Proxy</a
+          >
+          version {{.Version}}
+        </p>
+        {{ else }}
+        <p>{{.Footer}}</p>
+        {{ end }}
+      </div>
+    </footer>
+  </body>
+</html>
+{{end}}


### PR DESCRIPTION
A "better" solution for #51 leveraging the custom template functionality in oauth2-proxy which is poorly documented but explained in this issue https://github.com/oauth2-proxy/oauth2-proxy/issues/1507.

It's not tested but should be quick to iterate on internally. 