### PR TITLE
feat: add deadnix to remove dead nix code in `nix fmt`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,6 +101,7 @@
           nixpkgs-fmt.enable = true;
           shellcheck.enable = true;
           shfmt.enable = true;
+          deadnix.enable = true;
           statix = {
             enable = true;
             disabled-lints = [
@@ -122,6 +123,11 @@
             "org-config/app_configs/generated/**"
           ];
           formatter = {
+            # control the order in which nix formatters/linters are applied to ensure a correct and consistent outcome
+            deadnix.priority = 1;
+            statix.priority = 2;
+            nixpkgs-fmt.priority = 3;
+
             prettier = {
               options = [
                 "--trailing-comma"
@@ -144,7 +150,7 @@
         ./modules
         ./org-config
         flakeInputs.disko.nixosModules.default
-        ({ lib, pkgs, ... }: {
+        ({ pkgs, ... }: {
           imports = [
             nix-index-database.nixosModules.nix-index
           ];
@@ -213,7 +219,7 @@
               (final: prev: {
                 ocb-nixostools = final.callPackage ./scripts/python_nixostools { };
 
-                lib = (prev.lib.extend (import ./lib.nix)).extend (final: prev: {
+                lib = (prev.lib.extend (import ./lib.nix)).extend (final: _prev: {
                   # nixosSystem by default passes the import of nixpkgs' lib/default.nix.
                   # It is not aware of the overlay that we added when we created the nixpkgs
                   # instance, so we pass that extended lib here explicitly.
@@ -263,7 +269,7 @@
       #
       # nix-repl> configs.sshrelay2.time.timeZone
       # "Europe/Brussels"
-      configs = lib.mapAttrs (hostname: nixosConfig: nixosConfig.config) self.nixosConfigurations;
+      configs = lib.mapAttrs (_hostname: nixosConfig: nixosConfig.config) self.nixosConfigurations;
       # Target that can be used with nix-eval-jobs
       # In bash: nix build $(jq --raw-output '.drvPath | "\(.)^*"' < <(nix run 'nixpkgs#nix-eval-jobs' -- --flake '.#allSystems' --workers 4))
       # In fish: nix build (jq --raw-output '.drvPath | "\(.)^*"' < (nix run 'nixpkgs#nix-eval-jobs' -- --flake '.#allSystems' --workers 4 | psub))

--- a/modules/load_json.nix
+++ b/modules/load_json.nix
@@ -188,7 +188,7 @@
 
             # Resolve the given roles, after resolution we set the profile of
             # the resolved entries to a fixed specified one.
-            resolveEntriesWithProfiles = onEntryAbsent: entriesSeen: path:
+            resolveEntriesWithProfiles = _onEntryAbsent: entriesSeen: path:
               let
                 doResolve = resolveEntry onRoleAbsent entriesSeen path;
                 # Replace the profiles in the resolved role with the one

--- a/modules/nfs-client.nix
+++ b/modules/nfs-client.nix
@@ -31,7 +31,7 @@ in
     systemd = {
       mounts =
         let
-          mkMount = name: mount: {
+          mkMount = _name: mount: {
             enable = true;
             what = "${mount.what}";
             where = "${mount.where}";

--- a/modules/org.nix
+++ b/modules/org.nix
@@ -60,7 +60,7 @@ in
       reverse_tunnel =
         let
           relay_jsondata = lib.importJSON ../org-config/json/relay-servers.json;
-          addPublicKey = name: server: server // { inherit (relay_jsondata) public_key; };
+          addPublicKey = _name: server: server // { inherit (relay_jsondata) public_key; };
           relay_servers = lib.mapAttrs addPublicKey relay_jsondata.relay_servers;
         in
         {

--- a/modules/org_users.nix
+++ b/modules/org_users.nix
@@ -162,7 +162,7 @@ in
           }
         );
       } // lib.optionalAttrs (users_json.users ? expires)
-        (lib.mapAttrs (username: expire: { expires = expire; }) users_json.users.expires);
+        (lib.mapAttrs (_username: expire: { expires = expire; }) users_json.users.expires);
     };
 
     users.users = {

--- a/modules/server-lock.nix
+++ b/modules/server-lock.nix
@@ -3,7 +3,6 @@
 let
   cfg = config.settings.services.server-lock;
   crypto_cfg = config.settings.crypto;
-  sys_cfg = config.settings.system;
 in
 
 {

--- a/test.nix
+++ b/test.nix
@@ -1,10 +1,10 @@
-{ pkgs, pythonTest, qemu-common, test-instrumentation, defaultModules, hostConfigFunction, flakeInputs, hosts }:
+{ pkgs, pythonTest, qemu-common, test-instrumentation, defaultModules, flakeInputs, hosts }:
 with pkgs.lib;
 let
   nixosConfigurations =
     let
       hostOverrides = {
-        rescue-iso = config: {
+        rescue-iso = _config: {
           extraModules = [
             test-instrumentation
             {

--- a/tests/sshrelay.nix
+++ b/tests/sshrelay.nix
@@ -101,7 +101,7 @@ in
   };
 
   nodes = {
-    sshrelay1 = { lib, pkgs, nodes, ... }: {
+    sshrelay1 = { lib, nodes, ... }: {
       # The relay sits on both networks, so it's reachable by both machines
       virtualisation.vlans = [ 1 2 ];
 

--- a/tests/traefik.nix
+++ b/tests/traefik.nix
@@ -89,7 +89,7 @@ in
   };
 
   nodes = {
-    acme = { nodes, config, modulesPath, ... }: {
+    acme = { config, modulesPath, ... }: {
       imports = [
         (modulesPath + "/../tests/common/acme/server")
         (registerDnsModule { domain = config.test-support.acme.caDomain; })
@@ -252,7 +252,7 @@ in
         };
       };
 
-    client = { nodes, pkgs, ... }: {
+    client = { nodes, ... }: {
       # We need to trust the acme CA certificate since in the test script we will
       # download the CA certificate that the generated certificates were signed with.
       security.pki.certificateFiles = [
@@ -261,7 +261,7 @@ in
     };
 
     # Simple webserver to have something that traefik can proxy to
-    webserver = { nodes, config, pkgs, ... }:
+    webserver = { pkgs, ... }:
       let
         documentRoot = pkgs.runCommandLocal "docroot" { } ''
           mkdir -p "$out"


### PR DESCRIPTION
Adds https://github.com/astro/deadnix as part of formatting/linting nix code during `nix fmt` and configures an explicit priority for each nix related formatter to ensure they are applied in the correct order. 