### PR TITLE
Bump system-manager

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -243,11 +243,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773579282,
-        "narHash": "sha256-LWvZj9Bvm1EuoO6zbX4yjZebwnZNfeTbmCJGS7RGQ3Y=",
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a88de74db0e948139be4b46f9a94d64aa11391c",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
         "type": "github"
       },
       "original": {
@@ -417,11 +417,11 @@
         "userborn": "userborn"
       },
       "locked": {
-        "lastModified": 1773827232,
-        "narHash": "sha256-7oAUEjTDc7tgNYbaxrPTqJsq1CCh1hObkW8orBcvZNM=",
+        "lastModified": 1774344760,
+        "narHash": "sha256-wh4yR07t+axGzLwN1GCvbZX8zsgrvBuRHyRPg1HOIi4=",
         "owner": "numtide",
         "repo": "system-manager",
-        "rev": "617183f535579e431803403063182c040e2685d2",
+        "rev": "42acdacdb99a9674df1a502516871e33d9e0b862",
         "type": "github"
       },
       "original": {

--- a/modules/system-manager.nix
+++ b/modules/system-manager.nix
@@ -69,5 +69,10 @@
     # Override users.mutableUsers set by users.nix (false is for NixOS,
     # system-manager on Ubuntu should keep users mutable)
     users.mutableUsers = lib.mkForce true;
+
+    nix.enable = true;
+    environment.etc."nix/nix.conf".replaceExisting = true;
+
+    programs.ssh.enable = true;
   };
 }

--- a/org-config/hosts/ubuntu/demo001.nix
+++ b/org-config/hosts/ubuntu/demo001.nix
@@ -1,5 +1,4 @@
 {
   nixpkgs.hostPlatform = "x86_64-linux";
   settings.network.host_name = "demo001";
-  environment.etc."nix/nix.conf".replaceExisting = true;
 }


### PR DESCRIPTION
The nix module is now disabled by default. Enabling it. programs.ssh is also now disabled by default. Enabling it.