### PR TITLE
system-manager ssh reverse tunnel

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -417,11 +417,11 @@
         "userborn": "userborn"
       },
       "locked": {
-        "lastModified": 1774344760,
-        "narHash": "sha256-wh4yR07t+axGzLwN1GCvbZX8zsgrvBuRHyRPg1HOIi4=",
+        "lastModified": 1774356431,
+        "narHash": "sha256-rJXu3F4MibH9VBElraCgceZZdAaVapCYFMqL7VEFF+o=",
         "owner": "numtide",
         "repo": "system-manager",
-        "rev": "42acdacdb99a9674df1a502516871e33d9e0b862",
+        "rev": "62a1be911f9e24bdb357377587c73544c2aec719",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -247,6 +247,9 @@
         in
         lib.mkSystemManagerConfigurations {
           inherit flakeInputs hosts;
+          extraArgs = {
+            inherit flakeInputs;
+          };
           defaultModules = self.nixosModules.defaultUbuntu;
         };
 

--- a/modules/defaultUbuntu.nix
+++ b/modules/defaultUbuntu.nix
@@ -1,11 +1,15 @@
+{ flakeInputs, ... }:
 {
   imports = [
+    "${flakeInputs.nixpkgs-latest}/nixos/modules/services/security/fail2ban.nix"
+    "${flakeInputs.nixpkgs-latest}/nixos/modules/services/security/sshguard.nix"
     ./lib.nix
     ./load_json.nix
     ./org.nix
     ./org_users.nix
     ./reverse-tunnel.nix
     ./sudo.nix
+    ./sshd.nix
     ./system-manager.nix
     ./system-options.nix
     ./users.nix

--- a/modules/system-manager.nix
+++ b/modules/system-manager.nix
@@ -63,7 +63,6 @@
     # https://github.com/numtide/system-manager/issues/415
     users.users.tunnel = lib.mkIf config.settings.reverse_tunnel.enable {
       shell = lib.mkForce "/usr/sbin/nologin";
-      extraGroups = [ "ssh-group" ];
     };
     users.users.tunneller = lib.mkIf config.settings.reverse_tunnel.relay.enable {
       shell = lib.mkForce "/usr/sbin/nologin";

--- a/modules/system-manager.nix
+++ b/modules/system-manager.nix
@@ -14,12 +14,6 @@
       default = "";
     };
 
-    # Stub for NixOS services.openssh.ports (from nixos/modules/services/networking/ssh/sshd.nix)
-    services.openssh.ports = lib.mkOption {
-      type = lib.types.listOf lib.types.port;
-      default = [ 22 ];
-    };
-
     # From modules/network.nix
     settings.network.host_name = lib.mkOption {
       type = lib.types.host_name_type;
@@ -41,23 +35,12 @@
       default = { };
     };
 
-    # Extend user submodule with openssh.authorizedKeys (normally from sshd.nix)
-    users.users = lib.mkOption {
-      type = lib.types.attrsOf (
-        lib.types.submodule {
-          options.openssh.authorizedKeys = {
-            keys = lib.mkOption {
-              type = lib.types.listOf lib.types.str;
-              default = [ ];
-            };
-            keyFiles = lib.mkOption {
-              type = lib.types.listOf lib.types.path;
-              default = [ ];
-            };
-          };
-        }
-      );
+    services.openssh.startWhenNeeded = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
     };
+
+    networking.nftables.enable = lib.mkEnableOption "Mocked nftables";
   };
 
   config = {
@@ -74,5 +57,26 @@
     environment.etc."nix/nix.conf".replaceExisting = true;
 
     programs.ssh.enable = true;
+
+    # Overriding the upstream module. System-manager do not support
+    # setuid binaries for now. See
+    # https://github.com/numtide/system-manager/issues/415
+    users.users.tunnel = lib.mkIf config.settings.reverse_tunnel.enable {
+      shell = lib.mkForce "/usr/sbin/nologin";
+      extraGroups = [ "ssh-group" ];
+    };
+    users.users.tunneller = lib.mkIf config.settings.reverse_tunnel.relay.enable {
+      shell = lib.mkForce "/usr/sbin/nologin";
+    };
+    # systemd-manager disables sshd and use its own
+    # ssh-system-manager.service instead. There's no need for the
+    # sshd socket.
+    systemd.sockets.sshd.enable = false;
+    systemd.services = lib.mapAttrs' (
+      _: relay:
+      lib.nameValuePair "autossh-reverse-tunnel-${relay.name}" {
+        after = [ "ssh-system-manager.service" ];
+      }
+    ) config.settings.reverse_tunnel.relay_servers;
   };
 }

--- a/org-config/hosts/ubuntu/demo001.nix
+++ b/org-config/hosts/ubuntu/demo001.nix
@@ -1,4 +1,6 @@
+{ ... }:
 {
   nixpkgs.hostPlatform = "x86_64-linux";
   settings.network.host_name = "demo001";
+  networking.hostName = "demo001";
 }

--- a/tests/containers.nix
+++ b/tests/containers.nix
@@ -7,6 +7,54 @@
 }:
 let
   ubuntuTests = {
+    reverseTunnel =
+      let
+        toplevel = inputs.system-manager.lib.makeSystemConfig {
+          modules = [
+            ../org-config/hosts/ubuntu/demo001.nix
+            (
+              { lib, ... }:
+              {
+                settings.reverse_tunnel = {
+                  enable = true;
+                  tunnels = {
+                    demo001 = {
+                      name = "demo001";
+                      remote_forward_port = 2222;
+                      public_key = "";
+                    };
+                  };
+                };
+                #
+                users.users.tunnel.shell = lib.mkForce "/bin/nologin";
+              }
+            )
+          ]
+          ++ defaultUbuntuModules;
+          specialArgs = {
+            inherit lib;
+            flakeInputs = inputs;
+          };
+        };
+      in
+      inputs.system-manager.lib.containerTest.makeContainerTest {
+        hostPkgs = pkgs;
+        name = "reverse-tunnel-test";
+        inherit toplevel;
+        skipTypeCheck = true;
+        extraPathsToRegister = [ toplevel ];
+        testScript = ''
+          start_all()
+          demo001.wait_for_unit("multi-user.target")
+
+          activation_logs = machine.activate()
+          for line in activation_logs.split("\n"):
+              assert "ERROR" not in line, f"Activation error: {line}"
+
+          machine.wait_for_unit("system-manager.target")
+
+        '';
+      };
     demo001 =
       let
         toplevel = inputs.system-manager.lib.makeSystemConfig {

--- a/tests/containers.nix
+++ b/tests/containers.nix
@@ -9,24 +9,75 @@ let
   ubuntuTests = {
     reverseTunnel =
       let
+        tunnel = {
+          publicKey = lib.trim (lib.readFile ./data/id_tunnel.pub);
+          privateKey = ./data/id_tunnel;
+        };
         toplevel = inputs.system-manager.lib.makeSystemConfig {
           modules = [
-            ../org-config/hosts/ubuntu/demo001.nix
             (
-              { lib, ... }:
+              { ... }:
               {
+
+                nixpkgs.hostPlatform = "x86_64-linux";
+                settings.network.host_name = "test001";
+                networking.hostName = "test001";
+                environment.etc."ssh/ssh_host_ed25519_key" = {
+                  source = tunnel.privateKey;
+                  mode = "0400";
+                  replaceExisting = true;
+                };
+
+                services.openssh.hostKeys = [
+                  {
+                    path = "/etc/ssh/ssh_host_ed25519_key";
+                    type = "ed25519";
+                  }
+                ];
+                users.groups.ssh-users = { };
+
                 settings.reverse_tunnel = {
                   enable = true;
+                  privateTunnelKey = {
+                    group = "ssh-users";
+                    path = "${tunnel.privateKey}";
+                  };
                   tunnels = {
-                    demo001 = {
-                      name = "demo001";
-                      remote_forward_port = 2222;
-                      public_key = "";
+                    test001 = {
+                      name = "tunnel";
+                      public_key = tunnel.publicKey;
+                      # In production we have a very long connect timeout because we have
+                      # networks with very high latency.
+                      # This makes the test horribly slow though, so we use a very short
+                      # timeout here.
+                      connectTimeout = 1;
+                      remote_forward_port = 2323;
+                      reverse_tunnels.ssh = {
+                        forwarded_port = 22;
+                        prefix = 0;
+                      };
                     };
                   };
+                  relay_servers = {
+                    test001 = {
+                      public_key = tunnel.publicKey;
+                      addresses = [ "localhost" ];
+                    };
+                  };
+
+                  relay = {
+                    enable = true;
+                    tunnel.extraGroups = [ "ssh-rev-tun-users" ];
+                    # This is done by the user module in the full setup, based on the data
+                    # read from keys.json
+                    tunneller.keys = [
+                      {
+                        username = "client";
+                        inherit (tunnel) publicKey;
+                      }
+                    ];
+                  };
                 };
-                #
-                users.users.tunnel.shell = lib.mkForce "/bin/nologin";
               }
             )
           ]
@@ -45,14 +96,28 @@ let
         extraPathsToRegister = [ toplevel ];
         testScript = ''
           start_all()
-          demo001.wait_for_unit("multi-user.target")
+          machine.wait_for_unit("multi-user.target")
+
+          # For some reason, the ubuntu image is lacking the ssh host key.
+          # It's generated as a postinstall hook, so let's run it again.
+          machine.succeed("dpkg-reconfigure openssh-server")
+          # Configure by ubuntu. Will mess up with autossh.
 
           activation_logs = machine.activate()
           for line in activation_logs.split("\n"):
               assert "ERROR" not in line, f"Activation error: {line}"
 
           machine.wait_for_unit("system-manager.target")
-
+          machine.wait_for_unit("ssh-system-manager.service")
+          machine.wait_for_unit("autossh-reverse-tunnel-test001.service")
+          # The tunnel user shell is set to nologin, so we won't be able to log-in.
+          # That being said, if the tunnel works correctly, the host
+          # ssh daemon should be reachable through the 2323 reverse
+          # tunnel port and send us a error message when trying to
+          # log-in without a key.
+          machine.wait_for_open_port(2323)
+          res=machine.run('ssh -p 2323 tunnel@localhost | grep "tunnel@localhost: Permission denied (publickey)"')
+          assert "tunnel@localhost: Permission denied (publickey)" in res.stdout, "autossh does not seem to be exposing 2323"
         '';
       };
     demo001 =


### PR DESCRIPTION
commit 51d2b6c96d2e3f800d773f834b450e7d844808c0

    Adapt reverse-tunnel to be used from system-manager
    
    Importing the NixOS fail2ban and sshguard modules to the ubuntu
    system-manager config.
    
    The service mirrors almost exactly the NixOS one. There's one
    exception: the ssh daemon is launched on the machine startup instead
    of being started through socket activation.
    
    In practice, it won't make any difference: autossh hits the socket and
    starts the service as soon as the machine reaches multi-user.target.
    
commit 80f62f271b83e1b028e384f5aec3cfbd7a165798 

    Reverse-tunnel: test system-manager config
    
    For now, the container-based test driver only allow us to use a single
    machine per test. This is making this test a bit akward: everything is
    living on the same machine. The machine is running both the relay and
    a reverse tunnel.
    
    We're re-exposing the machine port 22 sshd to the 2323 port through a
    autossh tunnel going through the machine sshd running port 22.
    matriochka-style :)
    
    In the end, we're testing both the relay server and the reverse tunnel
    components in the same test and on the same machine.

Close #135 and #134 