### PR TITLE
refactor: extract nix config to dedicated module

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -191,7 +191,11 @@ let
               (toHostPath ("ubuntu/" + hostname))
               {
                 # Pass the set of all host names as a module input
-                _module.args = { inherit allUbuntuHosts; };
+                # Override system-manager's nixpkgs import with the wave-selected pkgs
+                _module.args = {
+                  inherit allUbuntuHosts;
+                  pkgs = lib.mkForce nixpkgs;
+                };
                 nixpkgs.hostPlatform = "x86_64-linux";
               }
             ]

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -10,6 +10,7 @@
     ./maintenance.nix
     ./network.nix
     ./nfs.nix
+    ./nix.nix
     ./packages.nix
     ./live_system.nix
     ./load_json.nix

--- a/modules/defaultUbuntu.nix
+++ b/modules/defaultUbuntu.nix
@@ -1,12 +1,14 @@
 { flakeInputs, ... }:
 {
   imports = [
+    "${flakeInputs.nixpkgs-latest}/nixos/modules/config/nix-flakes.nix"
     "${flakeInputs.nixpkgs-latest}/nixos/modules/services/misc/nix-gc.nix"
     "${flakeInputs.nixpkgs-latest}/nixos/modules/services/security/fail2ban.nix"
     "${flakeInputs.nixpkgs-latest}/nixos/modules/services/security/sshguard.nix"
     ./lib.nix
     ./load_json.nix
     ./maintenance.nix
+    ./nix.nix
     ./org.nix
     ./org_users.nix
     ./reverse-tunnel.nix

--- a/modules/nix.nix
+++ b/modules/nix.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  pkgs,
+  options,
+  ...
+}:
+
+let
+  isSystemManager = options ? system-manager;
+in
+
+{
+  config = {
+    nix = {
+      enable = true;
+
+      registry.nixpkgs = {
+        from = {
+          type = "indirect";
+          id = "nixpkgs";
+        };
+        flake = pkgs.nixpkgsFlake;
+      };
+
+      # man nix.conf
+      settings = {
+        auto-optimise-store = true;
+        trusted-users = [
+          "root"
+          "@wheel"
+        ];
+        builders-use-substitutes = true;
+        experimental-features = [
+          "nix-command"
+          "flakes"
+        ];
+        # Fall back to building from source if we cannot substitute
+        fallback = true;
+        # Disable the global flake registry
+        flake-registry = "";
+      };
+    }
+    // lib.optionalAttrs (!isSystemManager) {
+      nixPath = [
+        "nixpkgs=flake:nixpkgs"
+      ];
+    };
+  };
+}

--- a/modules/system.nix
+++ b/modules/system.nix
@@ -668,36 +668,6 @@ in
       );
     };
 
-    nix = {
-      nixPath = [
-        "nixpkgs=flake:nixpkgs"
-      ];
-      registry.nixpkgs = {
-        from = {
-          type = "indirect";
-          id = "nixpkgs";
-        };
-        flake = pkgs.nixpkgsFlake;
-      };
-      # man nix.conf
-      settings = {
-        auto-optimise-store = true;
-        trusted-users = [
-          "root"
-          "@wheel"
-        ];
-        builders-use-substitutes = true;
-        experimental-features = [
-          "nix-command"
-          "flakes"
-        ];
-        # Fall back to building from source if we cannot substitute
-        fallback = true;
-        # Disable the global flake registry
-        flake-registry = "";
-      };
-    };
-
     hardware = {
       enableRedistributableFirmware = true;
       cpu.intel.updateMicrocode = true;

--- a/tests/containers.nix
+++ b/tests/containers.nix
@@ -15,6 +15,8 @@ let
         };
         toplevel = inputs.system-manager.lib.makeSystemConfig {
           modules = [
+            # set pkgs just like evalSystemManagerHost does
+            { _module.args.pkgs = lib.mkForce pkgs; }
             (
               { ... }:
               {
@@ -123,6 +125,8 @@ let
       let
         toplevel = inputs.system-manager.lib.makeSystemConfig {
           modules = [
+            # set pkgs just like evalSystemManagerHost does
+            { _module.args.pkgs = lib.mkForce pkgs; }
             ../org-config/hosts/ubuntu/demo001.nix
           ]
           ++ defaultUbuntuModules;
@@ -185,6 +189,20 @@ let
             known_hosts = demo001.file("/etc/ssh/ssh_known_hosts")
             assert known_hosts.exists, "SSH known_hosts should exist"
             assert known_hosts.contains("demo-relay-1.ocb.msf.org,108.143.32.245 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINHILWx5iekpGR4s8N8d/Aa37Vgq8ZuxNs+7eT+YvMBU"), "SSH known_hosts should contain demo-relay-1.ocb.msf.org"
+
+          with subtest("nix config"):
+            nix_conf = demo001.file("/etc/nix/nix.conf")
+            assert nix_conf.exists, "Nix config should exist"
+            assert nix_conf.contains("experimental-features = nix-command flakes"), "Nix config should enable nix-command and flakes"
+            assert nix_conf.contains("auto-optimise-store = true"), "Nix config should enable auto-optimise-store"
+            assert nix_conf.contains("builders-use-substitutes = true"), "Nix config should enable builders-use-substitutes"
+            assert nix_conf.contains("fallback = true"), "Nix config should enable fallback"
+            assert nix_conf.contains("flake-registry = "), "Nix config should disable the global flake-registry"
+            assert nix_conf.contains("trusted-users = root @wheel"), "Nix config should trust root and the wheel group"
+
+            registry = demo001.file("/etc/nix/registry.json")
+            assert registry.exists, "Nix registry should exist"
+            assert registry.contains('"id":"nixpkgs"'), "Nix registry should contain a nixpkgs entry"
         '';
       };
   };


### PR DESCRIPTION
Move nix.settings, nix.registry, and nix.nixPath from system.nix to a new modules/nix.nix used by both nixos and system-manager.

nix.nixPath is not supported yet by system-manager, we are working  upstream on a solution to support it.