### PR TITLE
container tests: inject default args to all tests

### DIFF
--- a/tests/containers.nix
+++ b/tests/containers.nix
@@ -6,6 +6,13 @@
   ...
 }:
 let
+  # Add pkgs to top-level module.
+  _update_modules_default_args =
+    attrs: attrs // { modules = attrs.modules ++ [ { _module.args.pkgs = lib.mkForce pkgs; } ]; };
+  # Overriding system-manager makeSystemConfig to inject the extra nixpkgs top-level
+  # module argument usually injected by `evalSystemManagerHost`
+  makeSystemManagerConfig =
+    attrs: inputs.system-manager.lib.makeSystemConfig (_update_modules_default_args attrs);
   ubuntuTests = {
     reverseTunnel =
       let
@@ -13,10 +20,8 @@ let
           publicKey = lib.trim (lib.readFile ./data/id_tunnel.pub);
           privateKey = ./data/id_tunnel;
         };
-        toplevel = inputs.system-manager.lib.makeSystemConfig {
+        toplevel = makeSystemManagerConfig {
           modules = [
-            # set pkgs just like evalSystemManagerHost does
-            { _module.args.pkgs = lib.mkForce pkgs; }
             (
               { ... }:
               {
@@ -123,7 +128,7 @@ let
       };
     zabbixSetup =
       let
-        toplevel = inputs.system-manager.lib.makeSystemConfig {
+        toplevel = makeSystemManagerConfig {
           modules = [
             ../org-config/hosts/ubuntu/demo001.nix
             "${inputs.nixpkgs-latest}/nixos/modules/services/monitoring/zabbix-server.nix"
@@ -227,10 +232,8 @@ let
       };
     demo001 =
       let
-        toplevel = inputs.system-manager.lib.makeSystemConfig {
+        toplevel = makeSystemManagerConfig {
           modules = [
-            # set pkgs just like evalSystemManagerHost does
-            { _module.args.pkgs = lib.mkForce pkgs; }
             ../org-config/hosts/ubuntu/demo001.nix
           ]
           ++ defaultUbuntuModules;


### PR DESCRIPTION
This is usually done by makeSystemConfig, but we're not using it in the container tests and instead directly call
systemd-manager.lib.makeSystemConfig.

Factoring out the _module.args.pkgs we were manually injecting to all tests in a new makeSystemManager function that wraps the system-manager one and inject the required args.

Fixes the current eval error on main.