### PR TITLE
fix(sudo): make service-start commands work on system-manager hosts

### DIFF
--- a/modules/lib.nix
+++ b/modules/lib.nix
@@ -1,11 +1,16 @@
 {
   config,
   lib,
+  options,
   pkgs,
   ...
 }:
 
 let
+  isSystemManager = options ? system-manager;
+  systemctlPath =
+    if isSystemManager then "/usr/bin/systemctl" else "/run/current-system/sw/bin/systemctl";
+
   mkSudoStartServiceCmds =
     {
       serviceName,
@@ -13,7 +18,7 @@ let
     }:
     let
       optsStr = lib.concatStringsSep " " extraOpts;
-      mkStartCmd = service: "/run/current-system/sw/bin/systemctl ${optsStr} start ${service}";
+      mkStartCmd = service: "${systemctlPath} ${optsStr} start ${service}";
     in
     [
       (mkStartCmd serviceName)

--- a/modules/maintenance.nix
+++ b/modules/maintenance.nix
@@ -172,5 +172,16 @@ in
         options = "--delete-older-than 30d";
       };
     };
+
+    # Expose system-manager-upgrade under the NixOS name so that deploy
+    # tooling which hard-codes `nixos-upgrade.service` (the GitHub Actions
+    # workflow, the robot sudoers whitelist) works on system-manager hosts.
+    # systemd-level aliases cannot be used here — see
+    # https://github.com/numtide/system-manager/pull/464.
+    environment.etc = lib.mkIf (isSystemManager && cfg.nixos_upgrade.enable) {
+      "systemd/system/nixos-upgrade.service".source = "${
+        config.systemd.units."system-manager-upgrade.service".unit
+      }/system-manager-upgrade.service";
+    };
   };
 }

--- a/tests/containers.nix
+++ b/tests/containers.nix
@@ -265,7 +265,7 @@ let
           with subtest("sudoers"):
             sudoers = demo001.file("/etc/sudoers")
             assert sudoers.exists, "Sudoers file should exist"
-            assert sudoers.contains("robot     ALL=(root)    SETENV:NOPASSWD: !ALL, SETENV:NOPASSWD: /run/current-system/sw/bin/systemctl --system start nixos-upgrade, SETENV:NOPASSWD: /run/current-system/sw/bin/systemctl --system start nixos-upgrade.service, SETENV:NOPASSWD: /run/current-system/sw/bin/systemctl --system start nixos_rebuild_config, SETENV:NOPASSWD: /run/current-system/sw/bin/systemctl --system start nixos_rebuild_config.service"), "Robot user should have whitelisted systemctl commands"
+            assert sudoers.contains("robot     ALL=(root)    SETENV:NOPASSWD: !ALL, SETENV:NOPASSWD: /usr/bin/systemctl --system start nixos-upgrade, SETENV:NOPASSWD: /usr/bin/systemctl --system start nixos-upgrade.service, SETENV:NOPASSWD: /usr/bin/systemctl --system start nixos_rebuild_config, SETENV:NOPASSWD: /usr/bin/systemctl --system start nixos_rebuild_config.service"), "Robot user should have whitelisted systemctl commands"
             assert sudoers.contains("%wheel  ALL=(ALL:ALL)    NOPASSWD:SETENV: ALL"), "Wheel group should have passwordless sudo"
 
           with subtest("wheel group"):
@@ -291,6 +291,10 @@ let
             assert start_script.contains("--ssh-option -o IdentitiesOnly=yes"), "Service should enforce identity-only auth"
             assert start_script.contains("--ssh-option -o StrictHostKeyChecking=yes"), "Service should enforce strict host key checking"
             assert start_script.contains("--ssh-option -i"), "Service should specify the SSH private key"
+
+            alias_unit = demo001.file("/etc/systemd/system/nixos-upgrade.service")
+            assert alias_unit.is_symlink, "nixos-upgrade.service should be a symlink"
+            assert alias_unit.linked_to.endswith("/system-manager-upgrade.service"), "nixos-upgrade.service should resolve to the system-manager-upgrade.service unit file"
 
           with subtest("ssh relay"):
             known_hosts = demo001.file("/etc/ssh/ssh_known_hosts")


### PR DESCRIPTION
On Ubuntu hosts managed by system-manager, /run/current-system/sw/bin does not exist, so `mkSudoStartServiceCmds` must emit /usr/bin/systemctl instead.

Additionally, deploy tooling triggers nixos-upgrade.service. We need to expose the service as an alias of the `system-manager-upgrade.service`.