### PR TITLE
feat(install-ubuntu): support password-sudo bootstrap with -w

### DIFF
--- a/install-ubuntu.sh
+++ b/install-ubuntu.sh
@@ -31,6 +31,16 @@ if ((userelay)); then
 fi
 ssh_opts=("${ssh_common_opts[@]}" -p "${sshport}")
 
+# With -w, prompt once for the sudo password to install a NOPASSWD sudoers
+# fragment, then run everything else silently.
+# Without -w, assume passwordless sudo is already configured.
+ssh_bootstrap_opts=("${ssh_opts[@]}")
+sm_sudo_opts=()
+if ((sudopassword)); then
+  ssh_bootstrap_opts+=(-t)
+  sm_sudo_opts=(--sudo)
+fi
+
 # Build --ssh-option flags for system-manager from ssh_opts
 sm_ssh_opts=()
 for opt in "${ssh_opts[@]}"; do
@@ -41,12 +51,24 @@ ssh_target="${username}@${sshname}"
 
 generate_tunnel_key
 
+if ((sudopassword)); then
+  nopasswd_file="/etc/sudoers.d/99-install-${username}"
+  readonly nopasswd_file
+  # Chain onto generate_tunnel_key's tmpdir-cleanup trap so both run on exit.
+  # shellcheck disable=SC2064
+  trap "echo; echo 'Removing ${nopasswd_file} from target...'; ssh \"\${ssh_opts[@]}\" \"\${ssh_target}\" 'sudo rm -v -f ${nopasswd_file}' || echo \"WARNING: remote cleanup failed; please remove ${nopasswd_file} on the target manually\"; rm -rf \"\${extra_files}\"" EXIT
+  echo
+  echo "Installing temporary NOPASSWD sudoers fragment at ${nopasswd_file}..."
+  # shellcheck disable=SC2029
+  ssh "${ssh_bootstrap_opts[@]}" "${ssh_target}" "echo '${username} ALL=(ALL) NOPASSWD: ALL' | sudo tee ${nopasswd_file} >/dev/null && sudo chmod 0440 ${nopasswd_file}"
+fi
+
 echo
 echo "Checking if Nix is installed on ${ssh_target}..."
 # shellcheck disable=SC2029
 if ! ssh "${ssh_opts[@]}" "${ssh_target}" "command -v nix-store >/dev/null 2>&1"; then
   echo "Nix is not installed on the remote host. Installing..."
-  ssh "${ssh_opts[@]}" "${ssh_target}" "curl -sSfL https://artifacts.nixos.org/nix-installer | sh -s -- install --no-confirm"
+  ssh "${ssh_opts[@]}" "${ssh_target}" "curl -sSfL https://artifacts.nixos.org/nix-installer | sh -s -- install --no-confirm --extra-conf 'extra-trusted-users = ${username}'"
   echo "Nix installed successfully."
 else
   echo "Nix is already installed."
@@ -54,13 +76,25 @@ fi
 
 echo
 echo "Uploading tunnel key to ${ssh_target}..."
-ssh "${ssh_opts[@]}" "${ssh_target}" "sudo mkdir -p /var/lib/org-nix && sudo chown root:root /var/lib/org-nix && sudo chmod 755 /var/lib/org-nix"
 ssh "${ssh_opts[@]}" "${ssh_target}" "cat > /tmp/id_tunnel" <"${extra_files}/var/lib/org-nix/id_tunnel"
-ssh "${ssh_opts[@]}" "${ssh_target}" "sudo mv /tmp/id_tunnel /var/lib/org-nix/id_tunnel && sudo chown root:root /var/lib/org-nix/id_tunnel && sudo chmod 600 /var/lib/org-nix/id_tunnel"
+ssh "${ssh_opts[@]}" "${ssh_target}" "sudo bash -c 'mkdir -p /var/lib/org-nix && chown root:root /var/lib/org-nix && chmod 755 /var/lib/org-nix && mv /tmp/id_tunnel /var/lib/org-nix/id_tunnel && chown root:root /var/lib/org-nix/id_tunnel && chmod 600 /var/lib/org-nix/id_tunnel'"
+
+if ((sudopassword)); then
+  # Remove the NOPASSWD fragment now, while our ssh login still works.
+  # system-manager's new sshd only honors /etc/ssh/authorized_keys.d/%u
+  # (no ~/.ssh/authorized_keys), so the bootstrap user will get
+  # "Permission denied (publickey)" on any ssh attempt after activation.
+  echo
+  echo "Removing temporary NOPASSWD sudoers fragment at ${nopasswd_file}..."
+  # shellcheck disable=SC2029
+  ssh "${ssh_opts[@]}" "${ssh_target}" "sudo rm -v -f ${nopasswd_file}"
+  sm_sudo_opts+=(--ask-sudo-password)
+  trap 'rm -rf "${extra_files}"' EXIT
+fi
 
 echo
 echo "Deploying system-manager configuration for '${hostname}'..."
-system-manager switch --flake ".#${hostname}" --target-host "${ssh_target}" "${sm_ssh_opts[@]}"
+system-manager switch --flake ".#${hostname}" --target-host "${ssh_target}" "${sm_sudo_opts[@]}" "${sm_ssh_opts[@]}"
 
 update_tunnels_json
 

--- a/scripts/install-lib.sh
+++ b/scripts/install-lib.sh
@@ -4,13 +4,16 @@ umask 077
 
 function print_usage() {
   echo "Usage:"
-  echo "./$(basename "${0}") -H <hostname of target> -u <SSH username> -s <SSH name> [-p <SSH port>] [-r] [-S]"
+  echo "./$(basename "${0}") -H <hostname of target> -u <SSH username> -s <SSH name> [-p <SSH port>] [-r] [-S] [-w]"
   echo "Optional arguments:"
   echo "  -s: the SSH name, as specified in your SSH config, or IP address of the target machine"
   echo "      (this option is mandatory unless -r is specified)"
   echo "  -p: the SSH port, will use port 22 unless specified"
   echo "  -r: use the SSH relay to connect to the target machine"
   echo "  -S: don't attempt to add the new disk encryption secrets to the secrets mechanism"
+  echo "  -w: the target's sudo requires a password. Prompts password once to install a"
+  echo "      temporary NOPASSWD sudoers fragment so subsequent sudo calls are"
+  echo "      silent. The fragment is removed on exit."
 }
 
 function exit_usage() {
@@ -48,8 +51,9 @@ function parse_opts() {
   sshport=""
   declare -gi userelay=0
   declare -gi addsecrets=1
+  declare -gi sudopassword=0
 
-  while getopts ':u:H:s:p:rhS' flag; do
+  while getopts ':u:H:s:p:rhSw' flag; do
     case "${flag}" in
     u)
       if [[ ${OPTARG} =~ ^-. ]]; then
@@ -92,6 +96,9 @@ function parse_opts() {
     S)
       addsecrets=0
       ;;
+    w)
+      sudopassword=1
+      ;;
     :)
       echo
       echo "ERROR: invalid command-line option(s)"
@@ -118,8 +125,8 @@ function parse_opts() {
   fi
 
   # shellcheck disable=SC2034
-  readonly username hostname sshname sshport userelay addsecrets
-  export username hostname sshname sshport userelay addsecrets
+  readonly username hostname sshname sshport userelay addsecrets sudopassword
+  export username hostname sshname sshport userelay addsecrets sudopassword
 
   if [[ -z ${hostname} || -z ${username} || -z ${sshname} || -z ${sshport} ]]; then
     echo


### PR DESCRIPTION
Add a -w flag to install-ubuntu.sh for targets whose bootstrap user needs a password to run sudo. 

With -w the script prompts once to drop a temporary  /etc/sudoers.d/99-install-<user> NOPASSWD fragment, runs the Nix installer and tunnel-key setup silently, removes the fragment before system-manager switch (while our ssh still works under the pre-deploy sshd config), and lets system-manager prompt for the sudo password itself via --ask-sudo-password.

We also pass --extra-conf 'extra-trusted-users = <user>' to the Nix installer so the remote nix-daemon accepts unsigned store paths that system-manager pushes during the subsequent switch.